### PR TITLE
Add feature middle-click opens preferences

### DIFF
--- a/resources/po/de.po
+++ b/resources/po/de.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-11-30 18:36+0000\n"
-"PO-Revision-Date: 2025-11-30 18:06+0100\n"
+"PO-Revision-Date: 2025-12-01 20:03+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
 "Language: de\n"
@@ -919,7 +919,7 @@ msgstr "Farbe"
 
 #: src/lib/preferences/actions/actionDialog.ts:256
 msgid "Kind"
-msgstr ""
+msgstr "Art"
 
 #: src/lib/preferences/actions/actionDialog.ts:257
 #: src/lib/preferences/actions/actionDialog.ts:401

--- a/src/lib/ui/indicator.ts
+++ b/src/lib/ui/indicator.ts
@@ -148,7 +148,10 @@ export class ClipboardIndicator extends PanelMenu.Button {
 			this.emit('open-dialog');
 			return Clutter.EVENT_STOP;
 		}
-
+		if (event.type() === Clutter.EventType.BUTTON_PRESS && event.get_button() === Clutter.BUTTON_MIDDLE) {
+			this.ext.openPreferences();
+			return Clutter.EVENT_STOP;
+		}
 		return super.vfunc_event(event);
 	}
 


### PR DESCRIPTION
Enables middle-click on the indicator to open the extension's preferences.

This provides a quicker way to access the preferences panel.
