### PR TITLE
fix(indicator): restore left-click dialog open on GNOME 50+

### DIFF
--- a/src/lib/ui/indicator.ts
+++ b/src/lib/ui/indicator.ts
@@ -20,6 +20,7 @@ import { ClipboardHistory, ItemType } from '../common/constants.js';
 import { registerClass } from '../common/gjs.js';
 import { Icon, loadIcon } from '../common/icons.js';
 import { ClipboardEntry } from '../database/database.js';
+import { VERSION } from '../misc/compatibility.js';
 
 @registerClass({
 	Signals: {
@@ -83,6 +84,7 @@ export class ClipboardIndicator extends PanelMenu.Button {
 
 	constructor(private ext: CopyousExtension) {
 		super(0.5, ext.metadata.name, false);
+		this.configurePanelMenuClickGesture();
 
 		this._box = new St.BoxLayout({
 			style_class: 'copyous-indicator-box',
@@ -119,6 +121,16 @@ export class ClipboardIndicator extends PanelMenu.Button {
 		this.bind_property('incognito', this._incognitoSwitch, 'state', GObject.BindingFlags.BIDIRECTIONAL);
 
 		this.updateSettings();
+	}
+
+	private configurePanelMenuClickGesture() {
+		if (VERSION < 50) return;
+
+		(
+			this as ClipboardIndicator & {
+				_clickGesture?: { set_required_button: (button: number) => void };
+			}
+		)._clickGesture?.set_required_button(Clutter.BUTTON_SECONDARY);
 	}
 
 	get incognito() {


### PR DESCRIPTION
GNOME 50 changed PanelMenu.Button to use an internal ClickGesture that toggles the menu on press, causing left-click and right-click on the indicator to trigger the same menu action.

Configure the internal panel click gesture to require BUTTON_SECONDARY on GNOME 50+. This keeps right-click opening the indicator menu while restoring left-click behavior to open the clipboard dialog as intended.

Fixes #108 
Fixes #113 
Fixes #114 