### PR TITLE
Replace the old "Show Indicator" preference with "Show Clipboard Icon in Indicator"

### DIFF
--- a/resources/po/de.po
+++ b/resources/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-25 16:20-0500\n"
+"POT-Creation-Date: 2026-04-26 12:23-0500\n"
 "PO-Revision-Date: 2026-03-26 22:19+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -123,8 +123,8 @@ msgstr "Kopierte Farbe"
 
 #: src/lib/preferences/actions/actionDefaults.ts:72
 #: src/lib/preferences/general/feedbackSettings.ts:157
-#: src/lib/preferences/general/feedbackSettings.ts:261
-#: src/lib/preferences/general/feedbackSettings.ts:303
+#: src/lib/preferences/general/feedbackSettings.ts:259
+#: src/lib/preferences/general/feedbackSettings.ts:308
 #: src/lib/preferences/shortcuts/itemShortcuts.ts:39
 #: src/lib/ui/components/editDialog.ts:217
 #: src/lib/ui/components/editDialog.ts:244
@@ -626,6 +626,7 @@ msgstr "Die Sichtbarkeit der Kopfzeilensteuerelemente"
 
 #: src/lib/preferences/customization/headerCustomization.ts:34
 #: src/lib/preferences/customization/items/fileItemCustomization.ts:164
+#: src/lib/preferences/general/feedbackSettings.ts:230
 msgid "Hidden"
 msgstr "Versteckt"
 
@@ -1372,47 +1373,47 @@ msgstr ""
 "aus dem Zwischenablageverlauf ausgewählt werden"
 
 #: src/lib/preferences/general/feedbackSettings.ts:131
-#: src/lib/preferences/general/feedbackSettings.ts:253
+#: src/lib/preferences/general/feedbackSettings.ts:251
 msgid "Sound"
 msgstr "Ton"
 
 #: src/lib/preferences/general/feedbackSettings.ts:162
-#: src/lib/preferences/general/feedbackSettings.ts:305
+#: src/lib/preferences/general/feedbackSettings.ts:310
 msgid "Click"
 msgstr "Klick"
 
 #: src/lib/preferences/general/feedbackSettings.ts:163
-#: src/lib/preferences/general/feedbackSettings.ts:307
+#: src/lib/preferences/general/feedbackSettings.ts:312
 msgid "Hum"
 msgstr "Hum"
 
 #: src/lib/preferences/general/feedbackSettings.ts:164
-#: src/lib/preferences/general/feedbackSettings.ts:309
+#: src/lib/preferences/general/feedbackSettings.ts:314
 msgid "String"
 msgstr "Zeichenfolge"
 
 #: src/lib/preferences/general/feedbackSettings.ts:165
-#: src/lib/preferences/general/feedbackSettings.ts:311
+#: src/lib/preferences/general/feedbackSettings.ts:316
 msgid "Swing"
 msgstr "Schwung"
 
 #: src/lib/preferences/general/feedbackSettings.ts:166
-#: src/lib/preferences/general/feedbackSettings.ts:313
+#: src/lib/preferences/general/feedbackSettings.ts:318
 msgid "Message"
 msgstr "Nachricht"
 
 #: src/lib/preferences/general/feedbackSettings.ts:167
-#: src/lib/preferences/general/feedbackSettings.ts:315
+#: src/lib/preferences/general/feedbackSettings.ts:320
 msgid "Message New Instant"
 msgstr "Nachricht Neu Sofort"
 
 #: src/lib/preferences/general/feedbackSettings.ts:168
-#: src/lib/preferences/general/feedbackSettings.ts:317
+#: src/lib/preferences/general/feedbackSettings.ts:322
 msgid "Bell"
 msgstr "Glocke"
 
 #: src/lib/preferences/general/feedbackSettings.ts:169
-#: src/lib/preferences/general/feedbackSettings.ts:319
+#: src/lib/preferences/general/feedbackSettings.ts:324
 msgid "Dialog Warning"
 msgstr "Dialog Warnung"
 
@@ -1421,20 +1422,24 @@ msgid "Feedback"
 msgstr "Rückmeldung"
 
 #: src/lib/preferences/general/feedbackSettings.ts:227
-msgid "Show Clipboard Icon in Indicator"
+msgid "Indicator Display"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:228
-msgid "Show the clipboard icon in the indicator"
+msgid "Choose how the clipboard indicator appears in the top panel"
+msgstr ""
+
+#: src/lib/preferences/general/feedbackSettings.ts:231
+msgid "Icon Only"
+msgstr ""
+
+#: src/lib/preferences/general/feedbackSettings.ts:232
+msgid "Clipboard Content Only"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:233
-msgid "Show Clipboard Content in Indicator"
-msgstr "Inhalt der Zwischenablage in Indikator anzeigen"
-
-#: src/lib/preferences/general/feedbackSettings.ts:234
-msgid "Show the current clipboard content in the indicator"
-msgstr "Zeige den aktuellen Inhalt der Zwischenablage im Indikator an"
+msgid "Icon and Clipboard Content"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:239
 msgid "Wiggle Indicator"
@@ -1445,16 +1450,16 @@ msgid "Wiggle the indicator when a clipboard item is copied"
 msgstr ""
 "Bewege den Indikator, wenn ein Element aus der Zwischenablage kopiert wird"
 
-#: src/lib/preferences/general/feedbackSettings.ts:247
+#: src/lib/preferences/general/feedbackSettings.ts:245
 msgid "Send Notification"
 msgstr "Benachrichtigung senden"
 
-#: src/lib/preferences/general/feedbackSettings.ts:248
+#: src/lib/preferences/general/feedbackSettings.ts:246
 msgid "Send a notification when a clipboard item is copied"
 msgstr ""
 "Benachrichtigung senden, wenn ein Element in die Zwischenablage kopiert wird"
 
-#: src/lib/preferences/general/feedbackSettings.ts:254
+#: src/lib/preferences/general/feedbackSettings.ts:252
 msgid "Sound to play when a clipboard item is copied"
 msgstr "Ton, der beim Kopieren eines Clipboard-Elements abgespielt wird"
 
@@ -1803,7 +1808,7 @@ msgstr "Verlauf löschen"
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: src/lib/ui/indicator.ts:195
+#: src/lib/ui/indicator.ts:199
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -1911,11 +1916,17 @@ msgstr "Tastenkürzel"
 #~ msgid "Set the color scheme of the custom theme"
 #~ msgstr "Legen Sie das Farbschema des benutzerdefinierten Designs fest"
 
+#~ msgid "Show Clipboard Content in Indicator"
+#~ msgstr "Inhalt der Zwischenablage in Indikator anzeigen"
+
 #~ msgid "Show Indicator"
 #~ msgstr "Indikator anzeigen"
 
 #~ msgid "Show an indicator on the top panel"
 #~ msgstr "Zeige einen Indikator auf dem oberen Bedienfeld an"
+
+#~ msgid "Show the current clipboard content in the indicator"
+#~ msgstr "Zeige den aktuellen Inhalt der Zwischenablage im Indikator an"
 
 #~ msgid "Store clipboard history in memory instead of on disk"
 #~ msgstr ""

--- a/resources/po/de.po
+++ b/resources/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-20 15:54+0000\n"
+"POT-Creation-Date: 2026-04-25 16:20-0500\n"
 "PO-Revision-Date: 2026-03-26 22:19+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -1421,12 +1421,12 @@ msgid "Feedback"
 msgstr "Rückmeldung"
 
 #: src/lib/preferences/general/feedbackSettings.ts:227
-msgid "Show Indicator"
-msgstr "Indikator anzeigen"
+msgid "Show Clipboard Icon in Indicator"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:228
-msgid "Show an indicator on the top panel"
-msgstr "Zeige einen Indikator auf dem oberen Bedienfeld an"
+msgid "Show the clipboard icon in the indicator"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:233
 msgid "Show Clipboard Content in Indicator"
@@ -1436,11 +1436,11 @@ msgstr "Inhalt der Zwischenablage in Indikator anzeigen"
 msgid "Show the current clipboard content in the indicator"
 msgstr "Zeige den aktuellen Inhalt der Zwischenablage im Indikator an"
 
-#: src/lib/preferences/general/feedbackSettings.ts:241
+#: src/lib/preferences/general/feedbackSettings.ts:239
 msgid "Wiggle Indicator"
 msgstr "Indikator bewegen"
 
-#: src/lib/preferences/general/feedbackSettings.ts:242
+#: src/lib/preferences/general/feedbackSettings.ts:240
 msgid "Wiggle the indicator when a clipboard item is copied"
 msgstr ""
 "Bewege den Indikator, wenn ein Element aus der Zwischenablage kopiert wird"
@@ -1803,7 +1803,7 @@ msgstr "Verlauf löschen"
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: src/lib/ui/indicator.ts:191
+#: src/lib/ui/indicator.ts:195
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -1910,6 +1910,12 @@ msgstr "Tastenkürzel"
 
 #~ msgid "Set the color scheme of the custom theme"
 #~ msgstr "Legen Sie das Farbschema des benutzerdefinierten Designs fest"
+
+#~ msgid "Show Indicator"
+#~ msgstr "Indikator anzeigen"
+
+#~ msgid "Show an indicator on the top panel"
+#~ msgstr "Zeige einen Indikator auf dem oberen Bedienfeld an"
 
 #~ msgid "Store clipboard history in memory instead of on disk"
 #~ msgstr ""

--- a/resources/po/fr.po
+++ b/resources/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-25 16:20-0500\n"
+"POT-Creation-Date: 2026-04-26 12:23-0500\n"
 "PO-Revision-Date: 2025-12-06 04:59+0100\n"
 "Last-Translator: Axel Haustant <noirbizarre@gmail.com>\n"
 "Language-Team: \n"
@@ -123,8 +123,8 @@ msgstr "Couleur copiée"
 
 #: src/lib/preferences/actions/actionDefaults.ts:72
 #: src/lib/preferences/general/feedbackSettings.ts:157
-#: src/lib/preferences/general/feedbackSettings.ts:261
-#: src/lib/preferences/general/feedbackSettings.ts:303
+#: src/lib/preferences/general/feedbackSettings.ts:259
+#: src/lib/preferences/general/feedbackSettings.ts:308
 #: src/lib/preferences/shortcuts/itemShortcuts.ts:39
 #: src/lib/ui/components/editDialog.ts:217
 #: src/lib/ui/components/editDialog.ts:244
@@ -632,6 +632,7 @@ msgstr "La visibilité des contrôles de l'en-tête"
 
 #: src/lib/preferences/customization/headerCustomization.ts:34
 #: src/lib/preferences/customization/items/fileItemCustomization.ts:164
+#: src/lib/preferences/general/feedbackSettings.ts:230
 msgid "Hidden"
 msgstr "Masqué"
 
@@ -1378,47 +1379,47 @@ msgstr ""
 "sélectionnés dans l'historique du presse-papiers"
 
 #: src/lib/preferences/general/feedbackSettings.ts:131
-#: src/lib/preferences/general/feedbackSettings.ts:253
+#: src/lib/preferences/general/feedbackSettings.ts:251
 msgid "Sound"
 msgstr "Son"
 
 #: src/lib/preferences/general/feedbackSettings.ts:162
-#: src/lib/preferences/general/feedbackSettings.ts:305
+#: src/lib/preferences/general/feedbackSettings.ts:310
 msgid "Click"
 msgstr "Clic"
 
 #: src/lib/preferences/general/feedbackSettings.ts:163
-#: src/lib/preferences/general/feedbackSettings.ts:307
+#: src/lib/preferences/general/feedbackSettings.ts:312
 msgid "Hum"
 msgstr "Bourdonnement"
 
 #: src/lib/preferences/general/feedbackSettings.ts:164
-#: src/lib/preferences/general/feedbackSettings.ts:309
+#: src/lib/preferences/general/feedbackSettings.ts:314
 msgid "String"
 msgstr "Corde"
 
 #: src/lib/preferences/general/feedbackSettings.ts:165
-#: src/lib/preferences/general/feedbackSettings.ts:311
+#: src/lib/preferences/general/feedbackSettings.ts:316
 msgid "Swing"
 msgstr "Balançoire"
 
 #: src/lib/preferences/general/feedbackSettings.ts:166
-#: src/lib/preferences/general/feedbackSettings.ts:313
+#: src/lib/preferences/general/feedbackSettings.ts:318
 msgid "Message"
 msgstr "Message"
 
 #: src/lib/preferences/general/feedbackSettings.ts:167
-#: src/lib/preferences/general/feedbackSettings.ts:315
+#: src/lib/preferences/general/feedbackSettings.ts:320
 msgid "Message New Instant"
 msgstr "Message Nouveau Instantané"
 
 #: src/lib/preferences/general/feedbackSettings.ts:168
-#: src/lib/preferences/general/feedbackSettings.ts:317
+#: src/lib/preferences/general/feedbackSettings.ts:322
 msgid "Bell"
 msgstr "Cloche"
 
 #: src/lib/preferences/general/feedbackSettings.ts:169
-#: src/lib/preferences/general/feedbackSettings.ts:319
+#: src/lib/preferences/general/feedbackSettings.ts:324
 msgid "Dialog Warning"
 msgstr "Avertissement de boîte de dialogue"
 
@@ -1427,20 +1428,24 @@ msgid "Feedback"
 msgstr "Commentaires"
 
 #: src/lib/preferences/general/feedbackSettings.ts:227
-msgid "Show Clipboard Icon in Indicator"
+msgid "Indicator Display"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:228
-msgid "Show the clipboard icon in the indicator"
+msgid "Choose how the clipboard indicator appears in the top panel"
+msgstr ""
+
+#: src/lib/preferences/general/feedbackSettings.ts:231
+msgid "Icon Only"
+msgstr ""
+
+#: src/lib/preferences/general/feedbackSettings.ts:232
+msgid "Clipboard Content Only"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:233
-msgid "Show Clipboard Content in Indicator"
-msgstr "Affiche le contenu du presse-papiers dans l'indicateur"
-
-#: src/lib/preferences/general/feedbackSettings.ts:234
-msgid "Show the current clipboard content in the indicator"
-msgstr "Affiche le contenu actuel du presse-papier dans l'indicateur"
+msgid "Icon and Clipboard Content"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:239
 msgid "Wiggle Indicator"
@@ -1450,16 +1455,16 @@ msgstr "Agiter l'indicateur"
 msgid "Wiggle the indicator when a clipboard item is copied"
 msgstr "Agite l'indicateur lorsqu'un élément du presse-papiers est copié"
 
-#: src/lib/preferences/general/feedbackSettings.ts:247
+#: src/lib/preferences/general/feedbackSettings.ts:245
 msgid "Send Notification"
 msgstr "Envoyer une notification"
 
-#: src/lib/preferences/general/feedbackSettings.ts:248
+#: src/lib/preferences/general/feedbackSettings.ts:246
 msgid "Send a notification when a clipboard item is copied"
 msgstr ""
 "Envoie une notification lorsqu'un élément est copié dans le presse-papiers"
 
-#: src/lib/preferences/general/feedbackSettings.ts:254
+#: src/lib/preferences/general/feedbackSettings.ts:252
 msgid "Sound to play when a clipboard item is copied"
 msgstr "Son à jouer lorsqu'un élément du presse-papiers est copié"
 
@@ -1808,7 +1813,7 @@ msgstr "Effacer l'historique"
 msgid "Settings"
 msgstr "Paramètres"
 
-#: src/lib/ui/indicator.ts:195
+#: src/lib/ui/indicator.ts:199
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -1916,11 +1921,17 @@ msgstr "Raccourcis"
 #~ msgid "Set the color scheme of the custom theme"
 #~ msgstr "Définit le schéma de couleurs du thème personnalisé"
 
+#~ msgid "Show Clipboard Content in Indicator"
+#~ msgstr "Affiche le contenu du presse-papiers dans l'indicateur"
+
 #~ msgid "Show Indicator"
 #~ msgstr "Afficher l'indicateur"
 
 #~ msgid "Show an indicator on the top panel"
 #~ msgstr "Affiche un indicateur sur le panneau supérieur"
+
+#~ msgid "Show the current clipboard content in the indicator"
+#~ msgstr "Affiche le contenu actuel du presse-papier dans l'indicateur"
 
 #~ msgid "Store clipboard history in memory instead of on disk"
 #~ msgstr "Stocke l'historique du presse-papiers en mémoire au lieu du disque"

--- a/resources/po/fr.po
+++ b/resources/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-20 15:54+0000\n"
+"POT-Creation-Date: 2026-04-25 16:20-0500\n"
 "PO-Revision-Date: 2025-12-06 04:59+0100\n"
 "Last-Translator: Axel Haustant <noirbizarre@gmail.com>\n"
 "Language-Team: \n"
@@ -1174,8 +1174,8 @@ msgid ""
 "You can manually install highlight.js by downloading highlight.min.js from "
 "\"Url\" to \"Install Location\"."
 msgstr ""
-"Vous pouvez installer manuellement highlight.js en téléchargeant highlight."
-"min.js de \"Url\" vers \"Emplacement d'installation\"."
+"Vous pouvez installer manuellement highlight.js en téléchargeant "
+"highlight.min.js de \"Url\" vers \"Emplacement d'installation\"."
 
 #: src/lib/preferences/dependencies/dependencies.ts:208
 msgid "Url"
@@ -1427,12 +1427,12 @@ msgid "Feedback"
 msgstr "Commentaires"
 
 #: src/lib/preferences/general/feedbackSettings.ts:227
-msgid "Show Indicator"
-msgstr "Afficher l'indicateur"
+msgid "Show Clipboard Icon in Indicator"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:228
-msgid "Show an indicator on the top panel"
-msgstr "Affiche un indicateur sur le panneau supérieur"
+msgid "Show the clipboard icon in the indicator"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:233
 msgid "Show Clipboard Content in Indicator"
@@ -1442,11 +1442,11 @@ msgstr "Affiche le contenu du presse-papiers dans l'indicateur"
 msgid "Show the current clipboard content in the indicator"
 msgstr "Affiche le contenu actuel du presse-papier dans l'indicateur"
 
-#: src/lib/preferences/general/feedbackSettings.ts:241
+#: src/lib/preferences/general/feedbackSettings.ts:239
 msgid "Wiggle Indicator"
 msgstr "Agiter l'indicateur"
 
-#: src/lib/preferences/general/feedbackSettings.ts:242
+#: src/lib/preferences/general/feedbackSettings.ts:240
 msgid "Wiggle the indicator when a clipboard item is copied"
 msgstr "Agite l'indicateur lorsqu'un élément du presse-papiers est copié"
 
@@ -1808,7 +1808,7 @@ msgstr "Effacer l'historique"
 msgid "Settings"
 msgstr "Paramètres"
 
-#: src/lib/ui/indicator.ts:191
+#: src/lib/ui/indicator.ts:195
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -1915,6 +1915,12 @@ msgstr "Raccourcis"
 
 #~ msgid "Set the color scheme of the custom theme"
 #~ msgstr "Définit le schéma de couleurs du thème personnalisé"
+
+#~ msgid "Show Indicator"
+#~ msgstr "Afficher l'indicateur"
+
+#~ msgid "Show an indicator on the top panel"
+#~ msgstr "Affiche un indicateur sur le panneau supérieur"
 
 #~ msgid "Store clipboard history in memory instead of on disk"
 #~ msgstr "Stocke l'historique du presse-papiers en mémoire au lieu du disque"

--- a/resources/po/it.po
+++ b/resources/po/it.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-25 16:20-0500\n"
+"POT-Creation-Date: 2026-04-26 12:23-0500\n"
 "PO-Revision-Date: 2025-12-14 10:45+0100\n"
 "Last-Translator: Fabian Esposito <fabian.esposito@outlook.com>\n"
 "Language-Team: Italiano\n"
@@ -121,8 +121,8 @@ msgstr "Colore copiato"
 
 #: src/lib/preferences/actions/actionDefaults.ts:72
 #: src/lib/preferences/general/feedbackSettings.ts:157
-#: src/lib/preferences/general/feedbackSettings.ts:261
-#: src/lib/preferences/general/feedbackSettings.ts:303
+#: src/lib/preferences/general/feedbackSettings.ts:259
+#: src/lib/preferences/general/feedbackSettings.ts:308
 #: src/lib/preferences/shortcuts/itemShortcuts.ts:39
 #: src/lib/ui/components/editDialog.ts:217
 #: src/lib/ui/components/editDialog.ts:244
@@ -625,6 +625,7 @@ msgstr "La visibilità dei controlli dell'intestazione"
 
 #: src/lib/preferences/customization/headerCustomization.ts:34
 #: src/lib/preferences/customization/items/fileItemCustomization.ts:164
+#: src/lib/preferences/general/feedbackSettings.ts:230
 msgid "Hidden"
 msgstr "Nascosto"
 
@@ -1369,47 +1370,47 @@ msgstr ""
 "selezionati dalla cronologia"
 
 #: src/lib/preferences/general/feedbackSettings.ts:131
-#: src/lib/preferences/general/feedbackSettings.ts:253
+#: src/lib/preferences/general/feedbackSettings.ts:251
 msgid "Sound"
 msgstr "Suono"
 
 #: src/lib/preferences/general/feedbackSettings.ts:162
-#: src/lib/preferences/general/feedbackSettings.ts:305
+#: src/lib/preferences/general/feedbackSettings.ts:310
 msgid "Click"
 msgstr "Clic"
 
 #: src/lib/preferences/general/feedbackSettings.ts:163
-#: src/lib/preferences/general/feedbackSettings.ts:307
+#: src/lib/preferences/general/feedbackSettings.ts:312
 msgid "Hum"
 msgstr "Ronzio"
 
 #: src/lib/preferences/general/feedbackSettings.ts:164
-#: src/lib/preferences/general/feedbackSettings.ts:309
+#: src/lib/preferences/general/feedbackSettings.ts:314
 msgid "String"
 msgstr "Corda"
 
 #: src/lib/preferences/general/feedbackSettings.ts:165
-#: src/lib/preferences/general/feedbackSettings.ts:311
+#: src/lib/preferences/general/feedbackSettings.ts:316
 msgid "Swing"
 msgstr "Altalena"
 
 #: src/lib/preferences/general/feedbackSettings.ts:166
-#: src/lib/preferences/general/feedbackSettings.ts:313
+#: src/lib/preferences/general/feedbackSettings.ts:318
 msgid "Message"
 msgstr "Messaggio"
 
 #: src/lib/preferences/general/feedbackSettings.ts:167
-#: src/lib/preferences/general/feedbackSettings.ts:315
+#: src/lib/preferences/general/feedbackSettings.ts:320
 msgid "Message New Instant"
 msgstr "Messaggio Nuovo Istantaneo"
 
 #: src/lib/preferences/general/feedbackSettings.ts:168
-#: src/lib/preferences/general/feedbackSettings.ts:317
+#: src/lib/preferences/general/feedbackSettings.ts:322
 msgid "Bell"
 msgstr "Campana"
 
 #: src/lib/preferences/general/feedbackSettings.ts:169
-#: src/lib/preferences/general/feedbackSettings.ts:319
+#: src/lib/preferences/general/feedbackSettings.ts:324
 msgid "Dialog Warning"
 msgstr "Avviso di finestra di dialogo"
 
@@ -1418,20 +1419,24 @@ msgid "Feedback"
 msgstr "Feedback"
 
 #: src/lib/preferences/general/feedbackSettings.ts:227
-msgid "Show Clipboard Icon in Indicator"
+msgid "Indicator Display"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:228
-msgid "Show the clipboard icon in the indicator"
+msgid "Choose how the clipboard indicator appears in the top panel"
+msgstr ""
+
+#: src/lib/preferences/general/feedbackSettings.ts:231
+msgid "Icon Only"
+msgstr ""
+
+#: src/lib/preferences/general/feedbackSettings.ts:232
+msgid "Clipboard Content Only"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:233
-msgid "Show Clipboard Content in Indicator"
-msgstr "Mostra il contenuto degli appunti nell'indicatore"
-
-#: src/lib/preferences/general/feedbackSettings.ts:234
-msgid "Show the current clipboard content in the indicator"
-msgstr "Mostra il contenuto attuale degli appunti nell'indicatore"
+msgid "Icon and Clipboard Content"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:239
 msgid "Wiggle Indicator"
@@ -1441,16 +1446,16 @@ msgstr "Agita indicatore"
 msgid "Wiggle the indicator when a clipboard item is copied"
 msgstr "Agita l'indicatore quando un elemento degli appunti 00e8 copiato"
 
-#: src/lib/preferences/general/feedbackSettings.ts:247
+#: src/lib/preferences/general/feedbackSettings.ts:245
 msgid "Send Notification"
 msgstr "Invia notifica"
 
-#: src/lib/preferences/general/feedbackSettings.ts:248
+#: src/lib/preferences/general/feedbackSettings.ts:246
 msgid "Send a notification when a clipboard item is copied"
 msgstr ""
 "Envoie une notification lorsqu'un élément est copié dans le presse-papiers"
 
-#: src/lib/preferences/general/feedbackSettings.ts:254
+#: src/lib/preferences/general/feedbackSettings.ts:252
 msgid "Sound to play when a clipboard item is copied"
 msgstr "Suono da riprodurre quando un elemento degli appunti è copiato"
 
@@ -1798,7 +1803,7 @@ msgstr "Cancella la cronologia"
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: src/lib/ui/indicator.ts:195
+#: src/lib/ui/indicator.ts:199
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -1906,11 +1911,17 @@ msgstr "Scorciatoie"
 #~ msgid "Set the color scheme of the custom theme"
 #~ msgstr "Imposta lo schema di colori del tema personalizzato"
 
+#~ msgid "Show Clipboard Content in Indicator"
+#~ msgstr "Mostra il contenuto degli appunti nell'indicatore"
+
 #~ msgid "Show Indicator"
 #~ msgstr "Mostra indicatore"
 
 #~ msgid "Show an indicator on the top panel"
 #~ msgstr "Mostra un indicatore sul pannello superiore"
+
+#~ msgid "Show the current clipboard content in the indicator"
+#~ msgstr "Mostra il contenuto attuale degli appunti nell'indicatore"
 
 #~ msgid "Store clipboard history in memory instead of on disk"
 #~ msgstr "Archivia la cronologia degli appunti in memoria anziché su disco"

--- a/resources/po/it.po
+++ b/resources/po/it.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-20 15:54+0000\n"
+"POT-Creation-Date: 2026-04-25 16:20-0500\n"
 "PO-Revision-Date: 2025-12-14 10:45+0100\n"
 "Last-Translator: Fabian Esposito <fabian.esposito@outlook.com>\n"
 "Language-Team: Italiano\n"
@@ -1418,12 +1418,12 @@ msgid "Feedback"
 msgstr "Feedback"
 
 #: src/lib/preferences/general/feedbackSettings.ts:227
-msgid "Show Indicator"
-msgstr "Mostra indicatore"
+msgid "Show Clipboard Icon in Indicator"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:228
-msgid "Show an indicator on the top panel"
-msgstr "Mostra un indicatore sul pannello superiore"
+msgid "Show the clipboard icon in the indicator"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:233
 msgid "Show Clipboard Content in Indicator"
@@ -1433,11 +1433,11 @@ msgstr "Mostra il contenuto degli appunti nell'indicatore"
 msgid "Show the current clipboard content in the indicator"
 msgstr "Mostra il contenuto attuale degli appunti nell'indicatore"
 
-#: src/lib/preferences/general/feedbackSettings.ts:241
+#: src/lib/preferences/general/feedbackSettings.ts:239
 msgid "Wiggle Indicator"
 msgstr "Agita indicatore"
 
-#: src/lib/preferences/general/feedbackSettings.ts:242
+#: src/lib/preferences/general/feedbackSettings.ts:240
 msgid "Wiggle the indicator when a clipboard item is copied"
 msgstr "Agita l'indicatore quando un elemento degli appunti 00e8 copiato"
 
@@ -1798,7 +1798,7 @@ msgstr "Cancella la cronologia"
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: src/lib/ui/indicator.ts:191
+#: src/lib/ui/indicator.ts:195
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -1905,6 +1905,12 @@ msgstr "Scorciatoie"
 
 #~ msgid "Set the color scheme of the custom theme"
 #~ msgstr "Imposta lo schema di colori del tema personalizzato"
+
+#~ msgid "Show Indicator"
+#~ msgstr "Mostra indicatore"
+
+#~ msgid "Show an indicator on the top panel"
+#~ msgstr "Mostra un indicatore sul pannello superiore"
 
 #~ msgid "Store clipboard history in memory instead of on disk"
 #~ msgstr "Archivia la cronologia degli appunti in memoria anziché su disco"

--- a/resources/po/main.pot
+++ b/resources/po/main.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-20 15:54+0000\n"
+"POT-Creation-Date: 2026-04-25 16:20-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1373,11 +1373,11 @@ msgid "Feedback"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:227
-msgid "Show Indicator"
+msgid "Show Clipboard Icon in Indicator"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:228
-msgid "Show an indicator on the top panel"
+msgid "Show the clipboard icon in the indicator"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:233
@@ -1388,11 +1388,11 @@ msgstr ""
 msgid "Show the current clipboard content in the indicator"
 msgstr ""
 
-#: src/lib/preferences/general/feedbackSettings.ts:241
+#: src/lib/preferences/general/feedbackSettings.ts:239
 msgid "Wiggle Indicator"
 msgstr ""
 
-#: src/lib/preferences/general/feedbackSettings.ts:242
+#: src/lib/preferences/general/feedbackSettings.ts:240
 msgid "Wiggle the indicator when a clipboard item is copied"
 msgstr ""
 
@@ -1744,7 +1744,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: src/lib/ui/indicator.ts:191
+#: src/lib/ui/indicator.ts:195
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"

--- a/resources/po/main.pot
+++ b/resources/po/main.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-25 16:20-0500\n"
+"POT-Creation-Date: 2026-04-26 12:23-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -122,8 +122,8 @@ msgstr ""
 
 #: src/lib/preferences/actions/actionDefaults.ts:72
 #: src/lib/preferences/general/feedbackSettings.ts:157
-#: src/lib/preferences/general/feedbackSettings.ts:261
-#: src/lib/preferences/general/feedbackSettings.ts:303
+#: src/lib/preferences/general/feedbackSettings.ts:259
+#: src/lib/preferences/general/feedbackSettings.ts:308
 #: src/lib/preferences/shortcuts/itemShortcuts.ts:39
 #: src/lib/ui/components/editDialog.ts:217
 #: src/lib/ui/components/editDialog.ts:244
@@ -611,6 +611,7 @@ msgstr ""
 
 #: src/lib/preferences/customization/headerCustomization.ts:34
 #: src/lib/preferences/customization/items/fileItemCustomization.ts:164
+#: src/lib/preferences/general/feedbackSettings.ts:230
 msgid "Hidden"
 msgstr ""
 
@@ -1324,47 +1325,47 @@ msgid ""
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:131
-#: src/lib/preferences/general/feedbackSettings.ts:253
+#: src/lib/preferences/general/feedbackSettings.ts:251
 msgid "Sound"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:162
-#: src/lib/preferences/general/feedbackSettings.ts:305
+#: src/lib/preferences/general/feedbackSettings.ts:310
 msgid "Click"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:163
-#: src/lib/preferences/general/feedbackSettings.ts:307
+#: src/lib/preferences/general/feedbackSettings.ts:312
 msgid "Hum"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:164
-#: src/lib/preferences/general/feedbackSettings.ts:309
+#: src/lib/preferences/general/feedbackSettings.ts:314
 msgid "String"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:165
-#: src/lib/preferences/general/feedbackSettings.ts:311
+#: src/lib/preferences/general/feedbackSettings.ts:316
 msgid "Swing"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:166
-#: src/lib/preferences/general/feedbackSettings.ts:313
+#: src/lib/preferences/general/feedbackSettings.ts:318
 msgid "Message"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:167
-#: src/lib/preferences/general/feedbackSettings.ts:315
+#: src/lib/preferences/general/feedbackSettings.ts:320
 msgid "Message New Instant"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:168
-#: src/lib/preferences/general/feedbackSettings.ts:317
+#: src/lib/preferences/general/feedbackSettings.ts:322
 msgid "Bell"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:169
-#: src/lib/preferences/general/feedbackSettings.ts:319
+#: src/lib/preferences/general/feedbackSettings.ts:324
 msgid "Dialog Warning"
 msgstr ""
 
@@ -1373,19 +1374,23 @@ msgid "Feedback"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:227
-msgid "Show Clipboard Icon in Indicator"
+msgid "Indicator Display"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:228
-msgid "Show the clipboard icon in the indicator"
+msgid "Choose how the clipboard indicator appears in the top panel"
+msgstr ""
+
+#: src/lib/preferences/general/feedbackSettings.ts:231
+msgid "Icon Only"
+msgstr ""
+
+#: src/lib/preferences/general/feedbackSettings.ts:232
+msgid "Clipboard Content Only"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:233
-msgid "Show Clipboard Content in Indicator"
-msgstr ""
-
-#: src/lib/preferences/general/feedbackSettings.ts:234
-msgid "Show the current clipboard content in the indicator"
+msgid "Icon and Clipboard Content"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:239
@@ -1396,15 +1401,15 @@ msgstr ""
 msgid "Wiggle the indicator when a clipboard item is copied"
 msgstr ""
 
-#: src/lib/preferences/general/feedbackSettings.ts:247
+#: src/lib/preferences/general/feedbackSettings.ts:245
 msgid "Send Notification"
 msgstr ""
 
-#: src/lib/preferences/general/feedbackSettings.ts:248
+#: src/lib/preferences/general/feedbackSettings.ts:246
 msgid "Send a notification when a clipboard item is copied"
 msgstr ""
 
-#: src/lib/preferences/general/feedbackSettings.ts:254
+#: src/lib/preferences/general/feedbackSettings.ts:252
 msgid "Sound to play when a clipboard item is copied"
 msgstr ""
 
@@ -1744,7 +1749,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: src/lib/ui/indicator.ts:195
+#: src/lib/ui/indicator.ts:199
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"

--- a/resources/po/pl.po
+++ b/resources/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-25 16:20-0500\n"
+"POT-Creation-Date: 2026-04-26 12:23-0500\n"
 "PO-Revision-Date: 2026-04-17 08:33+0200\n"
 "Last-Translator: Adam Lewicki <a.lewicki95@gmail.com>\n"
 "Language-Team: \n"
@@ -125,8 +125,8 @@ msgstr "Skopiowany kolor"
 
 #: src/lib/preferences/actions/actionDefaults.ts:72
 #: src/lib/preferences/general/feedbackSettings.ts:157
-#: src/lib/preferences/general/feedbackSettings.ts:261
-#: src/lib/preferences/general/feedbackSettings.ts:303
+#: src/lib/preferences/general/feedbackSettings.ts:259
+#: src/lib/preferences/general/feedbackSettings.ts:308
 #: src/lib/preferences/shortcuts/itemShortcuts.ts:39
 #: src/lib/ui/components/editDialog.ts:217
 #: src/lib/ui/components/editDialog.ts:244
@@ -623,6 +623,7 @@ msgstr "Widoczność kontrolek nagłówka"
 
 #: src/lib/preferences/customization/headerCustomization.ts:34
 #: src/lib/preferences/customization/items/fileItemCustomization.ts:164
+#: src/lib/preferences/general/feedbackSettings.ts:230
 msgid "Hidden"
 msgstr "Ukryte"
 
@@ -1364,47 +1365,47 @@ msgstr ""
 "schowka"
 
 #: src/lib/preferences/general/feedbackSettings.ts:131
-#: src/lib/preferences/general/feedbackSettings.ts:253
+#: src/lib/preferences/general/feedbackSettings.ts:251
 msgid "Sound"
 msgstr "Dźwięk"
 
 #: src/lib/preferences/general/feedbackSettings.ts:162
-#: src/lib/preferences/general/feedbackSettings.ts:305
+#: src/lib/preferences/general/feedbackSettings.ts:310
 msgid "Click"
 msgstr "Klik"
 
 #: src/lib/preferences/general/feedbackSettings.ts:163
-#: src/lib/preferences/general/feedbackSettings.ts:307
+#: src/lib/preferences/general/feedbackSettings.ts:312
 msgid "Hum"
 msgstr "Brum"
 
 #: src/lib/preferences/general/feedbackSettings.ts:164
-#: src/lib/preferences/general/feedbackSettings.ts:309
+#: src/lib/preferences/general/feedbackSettings.ts:314
 msgid "String"
 msgstr "Plum"
 
 #: src/lib/preferences/general/feedbackSettings.ts:165
-#: src/lib/preferences/general/feedbackSettings.ts:311
+#: src/lib/preferences/general/feedbackSettings.ts:316
 msgid "Swing"
 msgstr "Buczenie"
 
 #: src/lib/preferences/general/feedbackSettings.ts:166
-#: src/lib/preferences/general/feedbackSettings.ts:313
+#: src/lib/preferences/general/feedbackSettings.ts:318
 msgid "Message"
 msgstr "Wiadomość"
 
 #: src/lib/preferences/general/feedbackSettings.ts:167
-#: src/lib/preferences/general/feedbackSettings.ts:315
+#: src/lib/preferences/general/feedbackSettings.ts:320
 msgid "Message New Instant"
 msgstr "Nowa natychmiastowa wiadomość"
 
 #: src/lib/preferences/general/feedbackSettings.ts:168
-#: src/lib/preferences/general/feedbackSettings.ts:317
+#: src/lib/preferences/general/feedbackSettings.ts:322
 msgid "Bell"
 msgstr "Dzwonek"
 
 #: src/lib/preferences/general/feedbackSettings.ts:169
-#: src/lib/preferences/general/feedbackSettings.ts:319
+#: src/lib/preferences/general/feedbackSettings.ts:324
 msgid "Dialog Warning"
 msgstr "Komunikat ostrzegawczy"
 
@@ -1413,20 +1414,24 @@ msgid "Feedback"
 msgstr "Opinie"
 
 #: src/lib/preferences/general/feedbackSettings.ts:227
-msgid "Show Clipboard Icon in Indicator"
+msgid "Indicator Display"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:228
-msgid "Show the clipboard icon in the indicator"
+msgid "Choose how the clipboard indicator appears in the top panel"
+msgstr ""
+
+#: src/lib/preferences/general/feedbackSettings.ts:231
+msgid "Icon Only"
+msgstr ""
+
+#: src/lib/preferences/general/feedbackSettings.ts:232
+msgid "Clipboard Content Only"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:233
-msgid "Show Clipboard Content in Indicator"
-msgstr "Pokaż zawartość schowka we wskaźniku"
-
-#: src/lib/preferences/general/feedbackSettings.ts:234
-msgid "Show the current clipboard content in the indicator"
-msgstr "Pokaż bieżącą zawartość schowka we wskaźniku"
+msgid "Icon and Clipboard Content"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:239
 msgid "Wiggle Indicator"
@@ -1436,15 +1441,15 @@ msgstr "Wskaźnik drgający"
 msgid "Wiggle the indicator when a clipboard item is copied"
 msgstr "Włącz drganie wskaźnika, gdy element zostanie skopiowany do schowka"
 
-#: src/lib/preferences/general/feedbackSettings.ts:247
+#: src/lib/preferences/general/feedbackSettings.ts:245
 msgid "Send Notification"
 msgstr "Wyślij powiadomienie"
 
-#: src/lib/preferences/general/feedbackSettings.ts:248
+#: src/lib/preferences/general/feedbackSettings.ts:246
 msgid "Send a notification when a clipboard item is copied"
 msgstr "Wyślij powiadomienie, gdy element zostanie skopiowany do schowka"
 
-#: src/lib/preferences/general/feedbackSettings.ts:254
+#: src/lib/preferences/general/feedbackSettings.ts:252
 msgid "Sound to play when a clipboard item is copied"
 msgstr "Dźwięk odtwarzany po skopiowaniu elementu do schowka"
 
@@ -1792,7 +1797,7 @@ msgstr "Wyczyść historię"
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: src/lib/ui/indicator.ts:195
+#: src/lib/ui/indicator.ts:199
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -2019,6 +2024,9 @@ msgstr "Skróty klawiszowe"
 #~ msgid "Shortcut to toggle incognito mode"
 #~ msgstr "Skrót do przełączenia trybu prywatnego"
 
+#~ msgid "Show Clipboard Content in Indicator"
+#~ msgstr "Pokaż zawartość schowka we wskaźniku"
+
 #~ msgid "Show Indicator"
 #~ msgstr "Pokaż wskaźnik"
 
@@ -2039,6 +2047,9 @@ msgstr "Skróty klawiszowe"
 
 #~ msgid "Show the clipboard dialog at the text cursor position"
 #~ msgstr "Pokaż okno dialogowe schowka w pozycji kursora tekstowego"
+
+#~ msgid "Show the current clipboard content in the indicator"
+#~ msgstr "Pokaż bieżącą zawartość schowka we wskaźniku"
 
 #~ msgid "Show the header of a clipboard item"
 #~ msgstr "Pokaż nagłówek elementu schowka'"

--- a/resources/po/pl.po
+++ b/resources/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-20 15:54+0000\n"
+"POT-Creation-Date: 2026-04-25 16:20-0500\n"
 "PO-Revision-Date: 2026-04-17 08:33+0200\n"
 "Last-Translator: Adam Lewicki <a.lewicki95@gmail.com>\n"
 "Language-Team: \n"
@@ -1413,12 +1413,12 @@ msgid "Feedback"
 msgstr "Opinie"
 
 #: src/lib/preferences/general/feedbackSettings.ts:227
-msgid "Show Indicator"
-msgstr "Pokaż wskaźnik"
+msgid "Show Clipboard Icon in Indicator"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:228
-msgid "Show an indicator on the top panel"
-msgstr "Pokaż wskaźnik na górnym panelu"
+msgid "Show the clipboard icon in the indicator"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:233
 msgid "Show Clipboard Content in Indicator"
@@ -1428,11 +1428,11 @@ msgstr "Pokaż zawartość schowka we wskaźniku"
 msgid "Show the current clipboard content in the indicator"
 msgstr "Pokaż bieżącą zawartość schowka we wskaźniku"
 
-#: src/lib/preferences/general/feedbackSettings.ts:241
+#: src/lib/preferences/general/feedbackSettings.ts:239
 msgid "Wiggle Indicator"
 msgstr "Wskaźnik drgający"
 
-#: src/lib/preferences/general/feedbackSettings.ts:242
+#: src/lib/preferences/general/feedbackSettings.ts:240
 msgid "Wiggle the indicator when a clipboard item is copied"
 msgstr "Włącz drganie wskaźnika, gdy element zostanie skopiowany do schowka"
 
@@ -1792,7 +1792,7 @@ msgstr "Wyczyść historię"
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: src/lib/ui/indicator.ts:191
+#: src/lib/ui/indicator.ts:195
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -2019,11 +2019,17 @@ msgstr "Skróty klawiszowe"
 #~ msgid "Shortcut to toggle incognito mode"
 #~ msgstr "Skrót do przełączenia trybu prywatnego"
 
+#~ msgid "Show Indicator"
+#~ msgstr "Pokaż wskaźnik"
+
 #~ msgid "Show a preview image of the link"
 #~ msgstr "Pokaż obraz podglądu odnośnika"
 
 #~ msgid "Show a preview of the link"
 #~ msgstr "Pokaż podgląd odnośnika"
+
+#~ msgid "Show an indicator on the top panel"
+#~ msgstr "Pokaż wskaźnik na górnym panelu"
 
 #~ msgid "Show extra information"
 #~ msgstr "Pokaż dodatkowe informacje"

--- a/resources/po/pt_BR.po
+++ b/resources/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-20 15:54+0000\n"
+"POT-Creation-Date: 2026-04-25 16:20-0500\n"
 "PO-Revision-Date: 2025-12-01 18:02-0300\n"
 "Last-Translator: Murilo Leal <murilormleal@outlook.com>\n"
 "Language-Team: Portuguese (Brazil)\n"
@@ -1404,12 +1404,12 @@ msgid "Feedback"
 msgstr "Feedback"
 
 #: src/lib/preferences/general/feedbackSettings.ts:227
-msgid "Show Indicator"
-msgstr "Mostrar indicador"
+msgid "Show Clipboard Icon in Indicator"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:228
-msgid "Show an indicator on the top panel"
-msgstr "Mostrar um indicador na barra superior"
+msgid "Show the clipboard icon in the indicator"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:233
 msgid "Show Clipboard Content in Indicator"
@@ -1419,11 +1419,11 @@ msgstr "Mostrar o Conteúdo da Área de trasnferência no Ponteiro"
 msgid "Show the current clipboard content in the indicator"
 msgstr "Mostrar o conteúdo da caixa da área de transferência no ponteiro"
 
-#: src/lib/preferences/general/feedbackSettings.ts:241
+#: src/lib/preferences/general/feedbackSettings.ts:239
 msgid "Wiggle Indicator"
 msgstr "Agitar Indicador"
 
-#: src/lib/preferences/general/feedbackSettings.ts:242
+#: src/lib/preferences/general/feedbackSettings.ts:240
 msgid "Wiggle the indicator when a clipboard item is copied"
 msgstr "Agitar o indicador quando um item da área de transferência é copiado"
 
@@ -1780,7 +1780,7 @@ msgstr "Limpar Histórico"
 msgid "Settings"
 msgstr "Configurações"
 
-#: src/lib/ui/indicator.ts:191
+#: src/lib/ui/indicator.ts:195
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -1887,6 +1887,12 @@ msgstr "Atalhos"
 
 #~ msgid "Set the color scheme of the custom theme"
 #~ msgstr "Seleciona o esquema de cor do tema customizado"
+
+#~ msgid "Show Indicator"
+#~ msgstr "Mostrar indicador"
+
+#~ msgid "Show an indicator on the top panel"
+#~ msgstr "Mostrar um indicador na barra superior"
 
 #~ msgid "Store clipboard history in memory instead of on disk"
 #~ msgstr "Armazenar histórico de clipboard em memória em vez de em disco"

--- a/resources/po/pt_BR.po
+++ b/resources/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-25 16:20-0500\n"
+"POT-Creation-Date: 2026-04-26 12:23-0500\n"
 "PO-Revision-Date: 2025-12-01 18:02-0300\n"
 "Last-Translator: Murilo Leal <murilormleal@outlook.com>\n"
 "Language-Team: Portuguese (Brazil)\n"
@@ -121,8 +121,8 @@ msgstr "Cor copiada"
 
 #: src/lib/preferences/actions/actionDefaults.ts:72
 #: src/lib/preferences/general/feedbackSettings.ts:157
-#: src/lib/preferences/general/feedbackSettings.ts:261
-#: src/lib/preferences/general/feedbackSettings.ts:303
+#: src/lib/preferences/general/feedbackSettings.ts:259
+#: src/lib/preferences/general/feedbackSettings.ts:308
 #: src/lib/preferences/shortcuts/itemShortcuts.ts:39
 #: src/lib/ui/components/editDialog.ts:217
 #: src/lib/ui/components/editDialog.ts:244
@@ -619,6 +619,7 @@ msgstr "O controle de visibilidade do cabeçalho"
 
 #: src/lib/preferences/customization/headerCustomization.ts:34
 #: src/lib/preferences/customization/items/fileItemCustomization.ts:164
+#: src/lib/preferences/general/feedbackSettings.ts:230
 msgid "Hidden"
 msgstr "Oculto"
 
@@ -1355,47 +1356,47 @@ msgstr ""
 "los do histórico"
 
 #: src/lib/preferences/general/feedbackSettings.ts:131
-#: src/lib/preferences/general/feedbackSettings.ts:253
+#: src/lib/preferences/general/feedbackSettings.ts:251
 msgid "Sound"
 msgstr "Som"
 
 #: src/lib/preferences/general/feedbackSettings.ts:162
-#: src/lib/preferences/general/feedbackSettings.ts:305
+#: src/lib/preferences/general/feedbackSettings.ts:310
 msgid "Click"
 msgstr "Clique"
 
 #: src/lib/preferences/general/feedbackSettings.ts:163
-#: src/lib/preferences/general/feedbackSettings.ts:307
+#: src/lib/preferences/general/feedbackSettings.ts:312
 msgid "Hum"
 msgstr "Hum"
 
 #: src/lib/preferences/general/feedbackSettings.ts:164
-#: src/lib/preferences/general/feedbackSettings.ts:309
+#: src/lib/preferences/general/feedbackSettings.ts:314
 msgid "String"
 msgstr "String"
 
 #: src/lib/preferences/general/feedbackSettings.ts:165
-#: src/lib/preferences/general/feedbackSettings.ts:311
+#: src/lib/preferences/general/feedbackSettings.ts:316
 msgid "Swing"
 msgstr "Swing"
 
 #: src/lib/preferences/general/feedbackSettings.ts:166
-#: src/lib/preferences/general/feedbackSettings.ts:313
+#: src/lib/preferences/general/feedbackSettings.ts:318
 msgid "Message"
 msgstr "Mensagem"
 
 #: src/lib/preferences/general/feedbackSettings.ts:167
-#: src/lib/preferences/general/feedbackSettings.ts:315
+#: src/lib/preferences/general/feedbackSettings.ts:320
 msgid "Message New Instant"
 msgstr "Mensagem Nova Instantânea"
 
 #: src/lib/preferences/general/feedbackSettings.ts:168
-#: src/lib/preferences/general/feedbackSettings.ts:317
+#: src/lib/preferences/general/feedbackSettings.ts:322
 msgid "Bell"
 msgstr "Sino"
 
 #: src/lib/preferences/general/feedbackSettings.ts:169
-#: src/lib/preferences/general/feedbackSettings.ts:319
+#: src/lib/preferences/general/feedbackSettings.ts:324
 msgid "Dialog Warning"
 msgstr "Aviso de Diálogo"
 
@@ -1404,20 +1405,24 @@ msgid "Feedback"
 msgstr "Feedback"
 
 #: src/lib/preferences/general/feedbackSettings.ts:227
-msgid "Show Clipboard Icon in Indicator"
+msgid "Indicator Display"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:228
-msgid "Show the clipboard icon in the indicator"
+msgid "Choose how the clipboard indicator appears in the top panel"
+msgstr ""
+
+#: src/lib/preferences/general/feedbackSettings.ts:231
+msgid "Icon Only"
+msgstr ""
+
+#: src/lib/preferences/general/feedbackSettings.ts:232
+msgid "Clipboard Content Only"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:233
-msgid "Show Clipboard Content in Indicator"
-msgstr "Mostrar o Conteúdo da Área de trasnferência no Ponteiro"
-
-#: src/lib/preferences/general/feedbackSettings.ts:234
-msgid "Show the current clipboard content in the indicator"
-msgstr "Mostrar o conteúdo da caixa da área de transferência no ponteiro"
+msgid "Icon and Clipboard Content"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:239
 msgid "Wiggle Indicator"
@@ -1427,16 +1432,16 @@ msgstr "Agitar Indicador"
 msgid "Wiggle the indicator when a clipboard item is copied"
 msgstr "Agitar o indicador quando um item da área de transferência é copiado"
 
-#: src/lib/preferences/general/feedbackSettings.ts:247
+#: src/lib/preferences/general/feedbackSettings.ts:245
 msgid "Send Notification"
 msgstr "Enviar notificação"
 
-#: src/lib/preferences/general/feedbackSettings.ts:248
+#: src/lib/preferences/general/feedbackSettings.ts:246
 msgid "Send a notification when a clipboard item is copied"
 msgstr ""
 "Enviar uma notificação quando um item da área de transferência for copiado"
 
-#: src/lib/preferences/general/feedbackSettings.ts:254
+#: src/lib/preferences/general/feedbackSettings.ts:252
 msgid "Sound to play when a clipboard item is copied"
 msgstr "Som a reproduzir quando um item da área de transferência for copiado"
 
@@ -1780,7 +1785,7 @@ msgstr "Limpar Histórico"
 msgid "Settings"
 msgstr "Configurações"
 
-#: src/lib/ui/indicator.ts:195
+#: src/lib/ui/indicator.ts:199
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -1888,11 +1893,17 @@ msgstr "Atalhos"
 #~ msgid "Set the color scheme of the custom theme"
 #~ msgstr "Seleciona o esquema de cor do tema customizado"
 
+#~ msgid "Show Clipboard Content in Indicator"
+#~ msgstr "Mostrar o Conteúdo da Área de trasnferência no Ponteiro"
+
 #~ msgid "Show Indicator"
 #~ msgstr "Mostrar indicador"
 
 #~ msgid "Show an indicator on the top panel"
 #~ msgstr "Mostrar um indicador na barra superior"
+
+#~ msgid "Show the current clipboard content in the indicator"
+#~ msgstr "Mostrar o conteúdo da caixa da área de transferência no ponteiro"
 
 #~ msgid "Store clipboard history in memory instead of on disk"
 #~ msgstr "Armazenar histórico de clipboard em memória em vez de em disco"

--- a/resources/po/ru.po
+++ b/resources/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-25 16:20-0500\n"
+"POT-Creation-Date: 2026-04-26 12:23-0500\n"
 "PO-Revision-Date: 2025-11-30 20:29+0700\n"
 "Last-Translator: Victor <firephantom303@gmail.com>\n"
 "Language-Team: Russian\n"
@@ -125,8 +125,8 @@ msgstr "Скопирован цвет"
 
 #: src/lib/preferences/actions/actionDefaults.ts:72
 #: src/lib/preferences/general/feedbackSettings.ts:157
-#: src/lib/preferences/general/feedbackSettings.ts:261
-#: src/lib/preferences/general/feedbackSettings.ts:303
+#: src/lib/preferences/general/feedbackSettings.ts:259
+#: src/lib/preferences/general/feedbackSettings.ts:308
 #: src/lib/preferences/shortcuts/itemShortcuts.ts:39
 #: src/lib/ui/components/editDialog.ts:217
 #: src/lib/ui/components/editDialog.ts:244
@@ -623,6 +623,7 @@ msgstr "Отображение элементов управления в заг
 
 #: src/lib/preferences/customization/headerCustomization.ts:34
 #: src/lib/preferences/customization/items/fileItemCustomization.ts:164
+#: src/lib/preferences/general/feedbackSettings.ts:230
 msgid "Hidden"
 msgstr "Скрыто"
 
@@ -1349,47 +1350,47 @@ msgstr ""
 "Обновлять дату копирования элементов при выборе их из истории буфера обмена"
 
 #: src/lib/preferences/general/feedbackSettings.ts:131
-#: src/lib/preferences/general/feedbackSettings.ts:253
+#: src/lib/preferences/general/feedbackSettings.ts:251
 msgid "Sound"
 msgstr "Звук"
 
 #: src/lib/preferences/general/feedbackSettings.ts:162
-#: src/lib/preferences/general/feedbackSettings.ts:305
+#: src/lib/preferences/general/feedbackSettings.ts:310
 msgid "Click"
 msgstr "Щелчок"
 
 #: src/lib/preferences/general/feedbackSettings.ts:163
-#: src/lib/preferences/general/feedbackSettings.ts:307
+#: src/lib/preferences/general/feedbackSettings.ts:312
 msgid "Hum"
 msgstr "Гудок"
 
 #: src/lib/preferences/general/feedbackSettings.ts:164
-#: src/lib/preferences/general/feedbackSettings.ts:309
+#: src/lib/preferences/general/feedbackSettings.ts:314
 msgid "String"
 msgstr "Струна"
 
 #: src/lib/preferences/general/feedbackSettings.ts:165
-#: src/lib/preferences/general/feedbackSettings.ts:311
+#: src/lib/preferences/general/feedbackSettings.ts:316
 msgid "Swing"
 msgstr "Свинг"
 
 #: src/lib/preferences/general/feedbackSettings.ts:166
-#: src/lib/preferences/general/feedbackSettings.ts:313
+#: src/lib/preferences/general/feedbackSettings.ts:318
 msgid "Message"
 msgstr "Сообщение"
 
 #: src/lib/preferences/general/feedbackSettings.ts:167
-#: src/lib/preferences/general/feedbackSettings.ts:315
+#: src/lib/preferences/general/feedbackSettings.ts:320
 msgid "Message New Instant"
 msgstr "Новое мгновенное сообщение"
 
 #: src/lib/preferences/general/feedbackSettings.ts:168
-#: src/lib/preferences/general/feedbackSettings.ts:317
+#: src/lib/preferences/general/feedbackSettings.ts:322
 msgid "Bell"
 msgstr "Звонок"
 
 #: src/lib/preferences/general/feedbackSettings.ts:169
-#: src/lib/preferences/general/feedbackSettings.ts:319
+#: src/lib/preferences/general/feedbackSettings.ts:324
 msgid "Dialog Warning"
 msgstr "Предупреждение диалогового окна"
 
@@ -1398,19 +1399,23 @@ msgid "Feedback"
 msgstr "Обратная связь"
 
 #: src/lib/preferences/general/feedbackSettings.ts:227
-msgid "Show Clipboard Icon in Indicator"
+msgid "Indicator Display"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:228
-msgid "Show the clipboard icon in the indicator"
+msgid "Choose how the clipboard indicator appears in the top panel"
+msgstr ""
+
+#: src/lib/preferences/general/feedbackSettings.ts:231
+msgid "Icon Only"
+msgstr ""
+
+#: src/lib/preferences/general/feedbackSettings.ts:232
+msgid "Clipboard Content Only"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:233
-msgid "Show Clipboard Content in Indicator"
-msgstr ""
-
-#: src/lib/preferences/general/feedbackSettings.ts:234
-msgid "Show the current clipboard content in the indicator"
+msgid "Icon and Clipboard Content"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:239
@@ -1421,15 +1426,15 @@ msgstr "Анимировать индикатор"
 msgid "Wiggle the indicator when a clipboard item is copied"
 msgstr "Анимировать индикатор при копировании элемента буфера обмена"
 
-#: src/lib/preferences/general/feedbackSettings.ts:247
+#: src/lib/preferences/general/feedbackSettings.ts:245
 msgid "Send Notification"
 msgstr "Отправлять уведомление"
 
-#: src/lib/preferences/general/feedbackSettings.ts:248
+#: src/lib/preferences/general/feedbackSettings.ts:246
 msgid "Send a notification when a clipboard item is copied"
 msgstr "Отправлять уведомление при копировании элемента буфера обмена"
 
-#: src/lib/preferences/general/feedbackSettings.ts:254
+#: src/lib/preferences/general/feedbackSettings.ts:252
 msgid "Sound to play when a clipboard item is copied"
 msgstr "Звук при копировании элемента буфера обмена"
 
@@ -1776,7 +1781,7 @@ msgstr "Очистить историю"
 msgid "Settings"
 msgstr "Настройки"
 
-#: src/lib/ui/indicator.ts:195
+#: src/lib/ui/indicator.ts:199
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"

--- a/resources/po/ru.po
+++ b/resources/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-20 15:54+0000\n"
+"POT-Creation-Date: 2026-04-25 16:20-0500\n"
 "PO-Revision-Date: 2025-11-30 20:29+0700\n"
 "Last-Translator: Victor <firephantom303@gmail.com>\n"
 "Language-Team: Russian\n"
@@ -1398,12 +1398,12 @@ msgid "Feedback"
 msgstr "Обратная связь"
 
 #: src/lib/preferences/general/feedbackSettings.ts:227
-msgid "Show Indicator"
-msgstr "Показывать индикатор"
+msgid "Show Clipboard Icon in Indicator"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:228
-msgid "Show an indicator on the top panel"
-msgstr "Показывать индикатор на верхней панели"
+msgid "Show the clipboard icon in the indicator"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:233
 msgid "Show Clipboard Content in Indicator"
@@ -1413,11 +1413,11 @@ msgstr ""
 msgid "Show the current clipboard content in the indicator"
 msgstr ""
 
-#: src/lib/preferences/general/feedbackSettings.ts:241
+#: src/lib/preferences/general/feedbackSettings.ts:239
 msgid "Wiggle Indicator"
 msgstr "Анимировать индикатор"
 
-#: src/lib/preferences/general/feedbackSettings.ts:242
+#: src/lib/preferences/general/feedbackSettings.ts:240
 msgid "Wiggle the indicator when a clipboard item is copied"
 msgstr "Анимировать индикатор при копировании элемента буфера обмена"
 
@@ -1776,7 +1776,7 @@ msgstr "Очистить историю"
 msgid "Settings"
 msgstr "Настройки"
 
-#: src/lib/ui/indicator.ts:191
+#: src/lib/ui/indicator.ts:195
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -1882,6 +1882,12 @@ msgstr "Сочетания клавиш"
 
 #~ msgid "Paste on Copy"
 #~ msgstr "Вставлять при копировании"
+
+#~ msgid "Show Indicator"
+#~ msgstr "Показывать индикатор"
+
+#~ msgid "Show an indicator on the top panel"
+#~ msgstr "Показывать индикатор на верхней панели"
 
 #~ msgid "Store clipboard history in memory instead of on disk"
 #~ msgstr "Хранить историю буфера обмена в памяти, а не на диске"

--- a/resources/po/tr.po
+++ b/resources/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-25 16:20-0500\n"
+"POT-Creation-Date: 2026-04-26 12:23-0500\n"
 "PO-Revision-Date: 2026-03-18 07:29+0300\n"
 "Last-Translator: Muha Aliss <muhaaliss@pm.me>\n"
 "Language-Team: Turkish\n"
@@ -123,8 +123,8 @@ msgstr "Renk Kopyalandı"
 
 #: src/lib/preferences/actions/actionDefaults.ts:72
 #: src/lib/preferences/general/feedbackSettings.ts:157
-#: src/lib/preferences/general/feedbackSettings.ts:261
-#: src/lib/preferences/general/feedbackSettings.ts:303
+#: src/lib/preferences/general/feedbackSettings.ts:259
+#: src/lib/preferences/general/feedbackSettings.ts:308
 #: src/lib/preferences/shortcuts/itemShortcuts.ts:39
 #: src/lib/ui/components/editDialog.ts:217
 #: src/lib/ui/components/editDialog.ts:244
@@ -621,6 +621,7 @@ msgstr "Başlık kontrollerinin görünürlüğü"
 
 #: src/lib/preferences/customization/headerCustomization.ts:34
 #: src/lib/preferences/customization/items/fileItemCustomization.ts:164
+#: src/lib/preferences/general/feedbackSettings.ts:230
 msgid "Hidden"
 msgstr "Gizli"
 
@@ -1354,47 +1355,47 @@ msgid ""
 msgstr "Pano geçmişinden bir öğe seçildiğinde kopyalanma tarihini güncelle"
 
 #: src/lib/preferences/general/feedbackSettings.ts:131
-#: src/lib/preferences/general/feedbackSettings.ts:253
+#: src/lib/preferences/general/feedbackSettings.ts:251
 msgid "Sound"
 msgstr "Ses"
 
 #: src/lib/preferences/general/feedbackSettings.ts:162
-#: src/lib/preferences/general/feedbackSettings.ts:305
+#: src/lib/preferences/general/feedbackSettings.ts:310
 msgid "Click"
 msgstr "Tık"
 
 #: src/lib/preferences/general/feedbackSettings.ts:163
-#: src/lib/preferences/general/feedbackSettings.ts:307
+#: src/lib/preferences/general/feedbackSettings.ts:312
 msgid "Hum"
 msgstr "Mırıltı"
 
 #: src/lib/preferences/general/feedbackSettings.ts:164
-#: src/lib/preferences/general/feedbackSettings.ts:309
+#: src/lib/preferences/general/feedbackSettings.ts:314
 msgid "String"
 msgstr "Dizi"
 
 #: src/lib/preferences/general/feedbackSettings.ts:165
-#: src/lib/preferences/general/feedbackSettings.ts:311
+#: src/lib/preferences/general/feedbackSettings.ts:316
 msgid "Swing"
 msgstr "Salınım"
 
 #: src/lib/preferences/general/feedbackSettings.ts:166
-#: src/lib/preferences/general/feedbackSettings.ts:313
+#: src/lib/preferences/general/feedbackSettings.ts:318
 msgid "Message"
 msgstr "Mesaj"
 
 #: src/lib/preferences/general/feedbackSettings.ts:167
-#: src/lib/preferences/general/feedbackSettings.ts:315
+#: src/lib/preferences/general/feedbackSettings.ts:320
 msgid "Message New Instant"
 msgstr "Yeni Anlık Mesaj"
 
 #: src/lib/preferences/general/feedbackSettings.ts:168
-#: src/lib/preferences/general/feedbackSettings.ts:317
+#: src/lib/preferences/general/feedbackSettings.ts:322
 msgid "Bell"
 msgstr "Zil"
 
 #: src/lib/preferences/general/feedbackSettings.ts:169
-#: src/lib/preferences/general/feedbackSettings.ts:319
+#: src/lib/preferences/general/feedbackSettings.ts:324
 msgid "Dialog Warning"
 msgstr "İletişim Kutusu Uyarısı"
 
@@ -1403,20 +1404,24 @@ msgid "Feedback"
 msgstr "Geri Bildirim"
 
 #: src/lib/preferences/general/feedbackSettings.ts:227
-msgid "Show Clipboard Icon in Indicator"
+msgid "Indicator Display"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:228
-msgid "Show the clipboard icon in the indicator"
+msgid "Choose how the clipboard indicator appears in the top panel"
+msgstr ""
+
+#: src/lib/preferences/general/feedbackSettings.ts:231
+msgid "Icon Only"
+msgstr ""
+
+#: src/lib/preferences/general/feedbackSettings.ts:232
+msgid "Clipboard Content Only"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:233
-msgid "Show Clipboard Content in Indicator"
-msgstr "Göstergede Pano İçeriğini Göster"
-
-#: src/lib/preferences/general/feedbackSettings.ts:234
-msgid "Show the current clipboard content in the indicator"
-msgstr "Göstergede mevcut pano içeriğini göster"
+msgid "Icon and Clipboard Content"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:239
 msgid "Wiggle Indicator"
@@ -1426,15 +1431,15 @@ msgstr "Göstergeyi Sallat"
 msgid "Wiggle the indicator when a clipboard item is copied"
 msgstr "Bir pano öğesi kopyalandığında göstergeyi salla"
 
-#: src/lib/preferences/general/feedbackSettings.ts:247
+#: src/lib/preferences/general/feedbackSettings.ts:245
 msgid "Send Notification"
 msgstr "Bildirim Gönder"
 
-#: src/lib/preferences/general/feedbackSettings.ts:248
+#: src/lib/preferences/general/feedbackSettings.ts:246
 msgid "Send a notification when a clipboard item is copied"
 msgstr "Bir pano öğesi kopyalandığında bildirim gönder"
 
-#: src/lib/preferences/general/feedbackSettings.ts:254
+#: src/lib/preferences/general/feedbackSettings.ts:252
 msgid "Sound to play when a clipboard item is copied"
 msgstr "Bir pano öğesi kopyalandığında çalınacak ses"
 
@@ -1780,7 +1785,7 @@ msgstr "Geçmişi Temizle"
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: src/lib/ui/indicator.ts:195
+#: src/lib/ui/indicator.ts:199
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -1886,11 +1891,17 @@ msgstr "Kısayollar"
 #~ msgid "Set the color scheme of the custom theme"
 #~ msgstr "Özel temanın renk şemasını ayarla"
 
+#~ msgid "Show Clipboard Content in Indicator"
+#~ msgstr "Göstergede Pano İçeriğini Göster"
+
 #~ msgid "Show Indicator"
 #~ msgstr "Göstergeyi Göster"
 
 #~ msgid "Show an indicator on the top panel"
 #~ msgstr "Üst panelde bir gösterge göster"
+
+#~ msgid "Show the current clipboard content in the indicator"
+#~ msgstr "Göstergede mevcut pano içeriğini göster"
 
 #~ msgid "Store clipboard history in memory instead of on disk"
 #~ msgstr "Pano geçmişini disk yerine bellekte sakla"

--- a/resources/po/tr.po
+++ b/resources/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-20 15:54+0000\n"
+"POT-Creation-Date: 2026-04-25 16:20-0500\n"
 "PO-Revision-Date: 2026-03-18 07:29+0300\n"
 "Last-Translator: Muha Aliss <muhaaliss@pm.me>\n"
 "Language-Team: Turkish\n"
@@ -1403,12 +1403,12 @@ msgid "Feedback"
 msgstr "Geri Bildirim"
 
 #: src/lib/preferences/general/feedbackSettings.ts:227
-msgid "Show Indicator"
-msgstr "Göstergeyi Göster"
+msgid "Show Clipboard Icon in Indicator"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:228
-msgid "Show an indicator on the top panel"
-msgstr "Üst panelde bir gösterge göster"
+msgid "Show the clipboard icon in the indicator"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:233
 msgid "Show Clipboard Content in Indicator"
@@ -1418,11 +1418,11 @@ msgstr "Göstergede Pano İçeriğini Göster"
 msgid "Show the current clipboard content in the indicator"
 msgstr "Göstergede mevcut pano içeriğini göster"
 
-#: src/lib/preferences/general/feedbackSettings.ts:241
+#: src/lib/preferences/general/feedbackSettings.ts:239
 msgid "Wiggle Indicator"
 msgstr "Göstergeyi Sallat"
 
-#: src/lib/preferences/general/feedbackSettings.ts:242
+#: src/lib/preferences/general/feedbackSettings.ts:240
 msgid "Wiggle the indicator when a clipboard item is copied"
 msgstr "Bir pano öğesi kopyalandığında göstergeyi salla"
 
@@ -1780,7 +1780,7 @@ msgstr "Geçmişi Temizle"
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: src/lib/ui/indicator.ts:191
+#: src/lib/ui/indicator.ts:195
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -1885,6 +1885,12 @@ msgstr "Kısayollar"
 
 #~ msgid "Set the color scheme of the custom theme"
 #~ msgstr "Özel temanın renk şemasını ayarla"
+
+#~ msgid "Show Indicator"
+#~ msgstr "Göstergeyi Göster"
+
+#~ msgid "Show an indicator on the top panel"
+#~ msgstr "Üst panelde bir gösterge göster"
 
 #~ msgid "Store clipboard history in memory instead of on disk"
 #~ msgstr "Pano geçmişini disk yerine bellekte sakla"

--- a/resources/po/zh_CN.po
+++ b/resources/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-25 16:20-0500\n"
+"POT-Creation-Date: 2026-04-26 12:23-0500\n"
 "PO-Revision-Date: 2025-12-19 18:30+0800\n"
 "Last-Translator: everyx <lunt.luo@gmail.com>\n"
 "Language-Team: Chinese (China)\n"
@@ -122,8 +122,8 @@ msgstr "已复制颜色"
 
 #: src/lib/preferences/actions/actionDefaults.ts:72
 #: src/lib/preferences/general/feedbackSettings.ts:157
-#: src/lib/preferences/general/feedbackSettings.ts:261
-#: src/lib/preferences/general/feedbackSettings.ts:303
+#: src/lib/preferences/general/feedbackSettings.ts:259
+#: src/lib/preferences/general/feedbackSettings.ts:308
 #: src/lib/preferences/shortcuts/itemShortcuts.ts:39
 #: src/lib/ui/components/editDialog.ts:217
 #: src/lib/ui/components/editDialog.ts:244
@@ -613,6 +613,7 @@ msgstr "标题栏控件的可见性"
 
 #: src/lib/preferences/customization/headerCustomization.ts:34
 #: src/lib/preferences/customization/items/fileItemCustomization.ts:164
+#: src/lib/preferences/general/feedbackSettings.ts:230
 msgid "Hidden"
 msgstr "隐藏"
 
@@ -1333,47 +1334,47 @@ msgid ""
 msgstr "从剪贴板历史记录中选择项目时更新其复制日期"
 
 #: src/lib/preferences/general/feedbackSettings.ts:131
-#: src/lib/preferences/general/feedbackSettings.ts:253
+#: src/lib/preferences/general/feedbackSettings.ts:251
 msgid "Sound"
 msgstr "提示音"
 
 #: src/lib/preferences/general/feedbackSettings.ts:162
-#: src/lib/preferences/general/feedbackSettings.ts:305
+#: src/lib/preferences/general/feedbackSettings.ts:310
 msgid "Click"
 msgstr "点击"
 
 #: src/lib/preferences/general/feedbackSettings.ts:163
-#: src/lib/preferences/general/feedbackSettings.ts:307
+#: src/lib/preferences/general/feedbackSettings.ts:312
 msgid "Hum"
 msgstr "蜂鸣"
 
 #: src/lib/preferences/general/feedbackSettings.ts:164
-#: src/lib/preferences/general/feedbackSettings.ts:309
+#: src/lib/preferences/general/feedbackSettings.ts:314
 msgid "String"
 msgstr "弦音"
 
 #: src/lib/preferences/general/feedbackSettings.ts:165
-#: src/lib/preferences/general/feedbackSettings.ts:311
+#: src/lib/preferences/general/feedbackSettings.ts:316
 msgid "Swing"
 msgstr "挥动"
 
 #: src/lib/preferences/general/feedbackSettings.ts:166
-#: src/lib/preferences/general/feedbackSettings.ts:313
+#: src/lib/preferences/general/feedbackSettings.ts:318
 msgid "Message"
 msgstr "消息"
 
 #: src/lib/preferences/general/feedbackSettings.ts:167
-#: src/lib/preferences/general/feedbackSettings.ts:315
+#: src/lib/preferences/general/feedbackSettings.ts:320
 msgid "Message New Instant"
 msgstr "即时消息"
 
 #: src/lib/preferences/general/feedbackSettings.ts:168
-#: src/lib/preferences/general/feedbackSettings.ts:317
+#: src/lib/preferences/general/feedbackSettings.ts:322
 msgid "Bell"
 msgstr "铃声"
 
 #: src/lib/preferences/general/feedbackSettings.ts:169
-#: src/lib/preferences/general/feedbackSettings.ts:319
+#: src/lib/preferences/general/feedbackSettings.ts:324
 msgid "Dialog Warning"
 msgstr "对话框警示"
 
@@ -1382,20 +1383,24 @@ msgid "Feedback"
 msgstr "反馈"
 
 #: src/lib/preferences/general/feedbackSettings.ts:227
-msgid "Show Clipboard Icon in Indicator"
+msgid "Indicator Display"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:228
-msgid "Show the clipboard icon in the indicator"
+msgid "Choose how the clipboard indicator appears in the top panel"
+msgstr ""
+
+#: src/lib/preferences/general/feedbackSettings.ts:231
+msgid "Icon Only"
+msgstr ""
+
+#: src/lib/preferences/general/feedbackSettings.ts:232
+msgid "Clipboard Content Only"
 msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:233
-msgid "Show Clipboard Content in Indicator"
-msgstr "在指示器中显示剪贴板内容"
-
-#: src/lib/preferences/general/feedbackSettings.ts:234
-msgid "Show the current clipboard content in the indicator"
-msgstr "在指示器中显示当前剪贴板内容"
+msgid "Icon and Clipboard Content"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:239
 msgid "Wiggle Indicator"
@@ -1405,15 +1410,15 @@ msgstr "抖动指示器"
 msgid "Wiggle the indicator when a clipboard item is copied"
 msgstr "复制剪贴板项时抖动指示器"
 
-#: src/lib/preferences/general/feedbackSettings.ts:247
+#: src/lib/preferences/general/feedbackSettings.ts:245
 msgid "Send Notification"
 msgstr "发送通知"
 
-#: src/lib/preferences/general/feedbackSettings.ts:248
+#: src/lib/preferences/general/feedbackSettings.ts:246
 msgid "Send a notification when a clipboard item is copied"
 msgstr "复制剪贴板项时发送通知"
 
-#: src/lib/preferences/general/feedbackSettings.ts:254
+#: src/lib/preferences/general/feedbackSettings.ts:252
 msgid "Sound to play when a clipboard item is copied"
 msgstr "复制剪贴板项时播放的声音"
 
@@ -1750,7 +1755,7 @@ msgstr "清理历史"
 msgid "Settings"
 msgstr "设置"
 
-#: src/lib/ui/indicator.ts:195
+#: src/lib/ui/indicator.ts:199
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -1853,11 +1858,17 @@ msgstr "快捷键"
 #~ msgid "Set the color scheme of the custom theme"
 #~ msgstr "设置自定义主题的配色方案"
 
+#~ msgid "Show Clipboard Content in Indicator"
+#~ msgstr "在指示器中显示剪贴板内容"
+
 #~ msgid "Show Indicator"
 #~ msgstr "显示指示器"
 
 #~ msgid "Show an indicator on the top panel"
 #~ msgstr "在顶部面板显示指示器"
+
+#~ msgid "Show the current clipboard content in the indicator"
+#~ msgstr "在指示器中显示当前剪贴板内容"
 
 #~ msgid "Store clipboard history in memory instead of on disk"
 #~ msgstr "将剪贴板历史记录存储在内存而非磁盘中"

--- a/resources/po/zh_CN.po
+++ b/resources/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-20 15:54+0000\n"
+"POT-Creation-Date: 2026-04-25 16:20-0500\n"
 "PO-Revision-Date: 2025-12-19 18:30+0800\n"
 "Last-Translator: everyx <lunt.luo@gmail.com>\n"
 "Language-Team: Chinese (China)\n"
@@ -1382,12 +1382,12 @@ msgid "Feedback"
 msgstr "反馈"
 
 #: src/lib/preferences/general/feedbackSettings.ts:227
-msgid "Show Indicator"
-msgstr "显示指示器"
+msgid "Show Clipboard Icon in Indicator"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:228
-msgid "Show an indicator on the top panel"
-msgstr "在顶部面板显示指示器"
+msgid "Show the clipboard icon in the indicator"
+msgstr ""
 
 #: src/lib/preferences/general/feedbackSettings.ts:233
 msgid "Show Clipboard Content in Indicator"
@@ -1397,11 +1397,11 @@ msgstr "在指示器中显示剪贴板内容"
 msgid "Show the current clipboard content in the indicator"
 msgstr "在指示器中显示当前剪贴板内容"
 
-#: src/lib/preferences/general/feedbackSettings.ts:241
+#: src/lib/preferences/general/feedbackSettings.ts:239
 msgid "Wiggle Indicator"
 msgstr "抖动指示器"
 
-#: src/lib/preferences/general/feedbackSettings.ts:242
+#: src/lib/preferences/general/feedbackSettings.ts:240
 msgid "Wiggle the indicator when a clipboard item is copied"
 msgstr "复制剪贴板项时抖动指示器"
 
@@ -1750,7 +1750,7 @@ msgstr "清理历史"
 msgid "Settings"
 msgstr "设置"
 
-#: src/lib/ui/indicator.ts:191
+#: src/lib/ui/indicator.ts:195
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -1852,6 +1852,12 @@ msgstr "快捷键"
 
 #~ msgid "Set the color scheme of the custom theme"
 #~ msgstr "设置自定义主题的配色方案"
+
+#~ msgid "Show Indicator"
+#~ msgstr "显示指示器"
+
+#~ msgid "Show an indicator on the top panel"
+#~ msgstr "在顶部面板显示指示器"
 
 #~ msgid "Store clipboard history in memory instead of on disk"
 #~ msgstr "将剪贴板历史记录存储在内存而非磁盘中"

--- a/resources/schemas/org.gnome.shell.extensions.copyous.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.copyous.gschema.xml
@@ -168,7 +168,7 @@
 		<!-- Feedback -->
 		<key name="show-indicator" type="b">
 			<default>true</default>
-			<summary>Show an indicator on the top panel</summary>
+			<summary>Show the clipboard icon in the indicator</summary>
 		</key>
 		<key name="show-content-indicator" type="b">
 			<default>false</default>

--- a/resources/schemas/org.gnome.shell.extensions.copyous.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.copyous.gschema.xml
@@ -63,6 +63,13 @@
 		<value nick="delete" value="2"/>
 	</enum>
 
+	<enum id="org.gnome.shell.extensions.copyous.IndicatorDisplay">
+		<value nick="hidden" value="0"/>
+		<value nick="icon-only" value="1"/>
+		<value nick="clipboard-content-only" value="2"/>
+		<value nick="icon-and-clipboard-content" value="3"/>
+	</enum>
+
 	<enum id="org.gnome.shell.extensions.copyous.TextCountMode">
 		<value nick="characters" value="0"/>
 		<value nick="words" value="1"/>
@@ -166,13 +173,17 @@
 		</key>
 
 		<!-- Feedback -->
+		<key name="indicator-display" enum="org.gnome.shell.extensions.copyous.IndicatorDisplay">
+			<default>'icon-only'</default>
+			<summary>Choose how the clipboard indicator appears in the top panel</summary>
+		</key>
 		<key name="show-indicator" type="b">
 			<default>true</default>
-			<summary>Show the clipboard icon in the indicator</summary>
+			<summary>Show the clipboard icon in the indicator (Deprecated)</summary>
 		</key>
 		<key name="show-content-indicator" type="b">
 			<default>false</default>
-			<summary>Show the current clipboard content in the indicator</summary>
+			<summary>Show the current clipboard content in the indicator (Deprecated)</summary>
 		</key>
 		<key name="wiggle-indicator" type="b">
 			<default>true</default>

--- a/src/lib/common/settings.ts
+++ b/src/lib/common/settings.ts
@@ -22,6 +22,7 @@ export const Settings = {
 	SyncPrimary: 'sync-primary',
 	UpdateDateOnCopy: 'update-date-on-copy',
 
+	IndicatorDisplay: 'indicator-display',
 	ShowIndicator: 'show-indicator',
 	ShowContentIndicator: 'show-content-indicator',
 	WiggleIndicator: 'wiggle-indicator',
@@ -152,8 +153,9 @@ export const SettingsTypes = {
 	[Settings.SyncPrimary]: 'boolean',
 	[Settings.UpdateDateOnCopy]: 'boolean',
 
-	[Settings.ShowIndicator]: 'boolean',
-	[Settings.ShowContentIndicator]: 'boolean',
+	[Settings.IndicatorDisplay]: 'enum',
+	[Settings.ShowIndicator]: 'boolean', // deprecated
+	[Settings.ShowContentIndicator]: 'boolean', // deprecated
 	[Settings.WiggleIndicator]: 'boolean',
 	[Settings.SendNotification]: 'boolean',
 	[Settings.Sound]: 'string',
@@ -368,9 +370,19 @@ export const MiddleClickAction = {
 
 export type MiddleClickAction = (typeof MiddleClickAction)[keyof typeof MiddleClickAction];
 
+export const IndicatorDisplay = {
+	Hidden: 0,
+	IconOnly: 1,
+	ClipboardContentOnly: 2,
+	IconAndClipboardContent: 3,
+} as const;
+
+export type IndicatorDisplay = (typeof IndicatorDisplay)[keyof typeof IndicatorDisplay];
+
 type SettingsEnumTypes = {
 	[Settings.DatabaseBackend]: DatabaseBackend;
 	[Settings.ClipboardHistory]: ClipboardHistory;
+	[Settings.IndicatorDisplay]: IndicatorDisplay;
 	[Settings.ClipboardOrientation]: Orientation;
 	[Settings.ClipboardPositionVertical]: Position;
 	[Settings.ClipboardPositionHorizontal]: Position;
@@ -522,9 +534,28 @@ export function bind_flags<T, TEnum extends { [K in KeysWithValue<T, 'enum'> | K
 	});
 }
 
+function getIndicatorDisplay(showIcon: boolean, showContent: boolean): IndicatorDisplay {
+	if (showIcon && showContent) return IndicatorDisplay.IconAndClipboardContent;
+	if (showIcon) return IndicatorDisplay.IconOnly;
+	if (showContent) return IndicatorDisplay.ClipboardContentOnly;
+	return IndicatorDisplay.Hidden;
+}
+
 export function migrateSettings(settings: CopyousSettings): void {
 	// inverted paste-on-copy -> swap-copy-shortcut
 	const pasteOnCopy = settings.get_user_value<'b'>('paste-on-copy');
 	if (pasteOnCopy !== null) settings.set_boolean('swap-copy-shortcut', !pasteOnCopy.get_boolean());
 	settings.reset('paste-on-copy');
+
+	// show-indicator + show-content-indicator -> indicator-display
+	const indicatorDisplay = settings.get_user_value('indicator-display');
+	const showIndicator = settings.get_user_value<'b'>('show-indicator');
+	const showContentIndicator = settings.get_user_value<'b'>('show-content-indicator');
+	if (indicatorDisplay === null && (showIndicator !== null || showContentIndicator !== null)) {
+		const showIcon = showIndicator?.get_boolean() ?? settings.get_boolean('show-indicator');
+		const showContent = showContentIndicator?.get_boolean() ?? settings.get_boolean('show-content-indicator');
+		settings.set_enum('indicator-display', getIndicatorDisplay(showIcon, showContent));
+	}
+	settings.reset('show-indicator');
+	settings.reset('show-content-indicator');
 }

--- a/src/lib/preferences/general/feedbackSettings.ts
+++ b/src/lib/preferences/general/feedbackSettings.ts
@@ -223,25 +223,25 @@ export class FeedbackSettings extends Adw.PreferencesGroup {
 			title: _('Feedback'),
 		});
 
-		const showIndicator = new Adw.SwitchRow({
-			title: _('Show Indicator'),
-			subtitle: _('Show an indicator on the top panel'),
+		const showIconIndicator = new Adw.SwitchRow({
+			title: _('Show Clipboard Icon in Indicator'),
+			subtitle: _('Show the clipboard icon in the indicator'),
 		});
-		this.add(showIndicator);
+		this.add(showIconIndicator);
 
 		const showContentIndicator = new Adw.SwitchRow({
 			title: _('Show Clipboard Content in Indicator'),
 			subtitle: _('Show the current clipboard content in the indicator'),
 		});
 		this.add(showContentIndicator);
-		showIndicator.bind_property('active', showContentIndicator, 'sensitive', null);
-		this.connect('map', () => (showContentIndicator.sensitive = showIndicator.active));
 
 		const wiggleIndicator = new Adw.SwitchRow({
 			title: _('Wiggle Indicator'),
 			subtitle: _('Wiggle the indicator when a clipboard item is copied'),
 		});
 		this.add(wiggleIndicator);
+		showIconIndicator.bind_property('active', wiggleIndicator, 'sensitive', null);
+		this.connect('map', () => (wiggleIndicator.sensitive = showIconIndicator.active));
 
 		const sendNotification = new Adw.SwitchRow({
 			title: _('Send Notification'),
@@ -269,7 +269,7 @@ export class FeedbackSettings extends Adw.PreferencesGroup {
 
 		// Bind properties
 		const settings: CopyousSettings = prefs.getSettings();
-		settings.bind('show-indicator', showIndicator, 'active', Gio.SettingsBindFlags.DEFAULT);
+		settings.bind('show-indicator', showIconIndicator, 'active', Gio.SettingsBindFlags.DEFAULT);
 		settings.bind('show-content-indicator', showContentIndicator, 'active', Gio.SettingsBindFlags.DEFAULT);
 		settings.bind('wiggle-indicator', wiggleIndicator, 'active', Gio.SettingsBindFlags.DEFAULT);
 		settings.bind('send-notification', sendNotification, 'active', Gio.SettingsBindFlags.DEFAULT);

--- a/src/lib/preferences/general/feedbackSettings.ts
+++ b/src/lib/preferences/general/feedbackSettings.ts
@@ -8,7 +8,7 @@ import { gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensio
 import Preferences from '../../../prefs.js';
 import { registerClass } from '../../common/gjs.js';
 import { Icon } from '../../common/icons.js';
-import { CopyousSettings } from '../../common/settings.js';
+import { CopyousSettings, IndicatorDisplay, bind_enum } from '../../common/settings.js';
 import { Sound, SoundManager } from '../../common/sound.js';
 import { makeResettable } from '../utils.js';
 
@@ -223,25 +223,23 @@ export class FeedbackSettings extends Adw.PreferencesGroup {
 			title: _('Feedback'),
 		});
 
-		const showIconIndicator = new Adw.SwitchRow({
-			title: _('Show Clipboard Icon in Indicator'),
-			subtitle: _('Show the clipboard icon in the indicator'),
+		const indicatorDisplay = new Adw.ComboRow({
+			title: _('Indicator Display'),
+			subtitle: _('Choose how the clipboard indicator appears in the top panel'),
+			model: Gtk.StringList.new([
+				_('Hidden'),
+				_('Icon Only'),
+				_('Clipboard Content Only'),
+				_('Icon and Clipboard Content'),
+			]),
 		});
-		this.add(showIconIndicator);
-
-		const showContentIndicator = new Adw.SwitchRow({
-			title: _('Show Clipboard Content in Indicator'),
-			subtitle: _('Show the current clipboard content in the indicator'),
-		});
-		this.add(showContentIndicator);
+		this.add(indicatorDisplay);
 
 		const wiggleIndicator = new Adw.SwitchRow({
 			title: _('Wiggle Indicator'),
 			subtitle: _('Wiggle the indicator when a clipboard item is copied'),
 		});
 		this.add(wiggleIndicator);
-		showIconIndicator.bind_property('active', wiggleIndicator, 'sensitive', null);
-		this.connect('map', () => (wiggleIndicator.sensitive = showIconIndicator.active));
 
 		const sendNotification = new Adw.SwitchRow({
 			title: _('Send Notification'),
@@ -269,10 +267,17 @@ export class FeedbackSettings extends Adw.PreferencesGroup {
 
 		// Bind properties
 		const settings: CopyousSettings = prefs.getSettings();
-		settings.bind('show-indicator', showIconIndicator, 'active', Gio.SettingsBindFlags.DEFAULT);
-		settings.bind('show-content-indicator', showContentIndicator, 'active', Gio.SettingsBindFlags.DEFAULT);
+		bind_enum(settings, 'indicator-display', indicatorDisplay, 'selected');
 		settings.bind('wiggle-indicator', wiggleIndicator, 'active', Gio.SettingsBindFlags.DEFAULT);
 		settings.bind('send-notification', sendNotification, 'active', Gio.SettingsBindFlags.DEFAULT);
+
+		const updateWiggleSensitivity = () => {
+			wiggleIndicator.sensitive =
+				indicatorDisplay.selected === IndicatorDisplay.IconOnly ||
+				indicatorDisplay.selected === IndicatorDisplay.IconAndClipboardContent;
+		};
+		indicatorDisplay.connect('notify::selected', updateWiggleSensitivity);
+		updateWiggleSensitivity();
 
 		makeResettable(playSound, settings, 'sound', 'volume');
 

--- a/src/lib/ui/indicator.ts
+++ b/src/lib/ui/indicator.ts
@@ -155,8 +155,12 @@ export class ClipboardIndicator extends PanelMenu.Button {
 	}
 
 	private updateSettings() {
-		this.visible = this.ext.settings.get_boolean('show-indicator');
-		if (this._previewWidget) this._previewWidget.visible = this.ext.settings.get_boolean('show-content-indicator');
+		const showIconIndicator = this.ext.settings.get_boolean('show-indicator');
+		const showContentIndicator = this.ext.settings.get_boolean('show-content-indicator');
+
+		this.visible = showIconIndicator || showContentIndicator;
+		this._icon.visible = showIconIndicator;
+		if (this._previewWidget) this._previewWidget.visible = showContentIndicator;
 		this.incognito = this.ext.settings.get_boolean('incognito');
 	}
 
@@ -165,7 +169,7 @@ export class ClipboardIndicator extends PanelMenu.Button {
 	}
 
 	animate() {
-		if (this.ext.settings.get_boolean('wiggle-indicator')) {
+		if (this._icon.visible && this.ext.settings.get_boolean('wiggle-indicator')) {
 			animationUtils.wiggle(this._icon, { offset: 2, duration: 65, wiggleCount: 3 });
 		}
 	}

--- a/src/lib/ui/indicator.ts
+++ b/src/lib/ui/indicator.ts
@@ -19,7 +19,7 @@ import { Color } from '../common/color.js';
 import { ItemType } from '../common/constants.js';
 import { registerClass } from '../common/gjs.js';
 import { Icon, loadIcon } from '../common/icons.js';
-import { ClipboardHistory } from '../common/settings.js';
+import { ClipboardHistory, IndicatorDisplay } from '../common/settings.js';
 import { ClipboardEntry } from '../database/database.js';
 import { VERSION } from '../misc/compatibility.js';
 
@@ -110,9 +110,7 @@ export class ClipboardIndicator extends PanelMenu.Button {
 
 		// Bind properties
 		this.ext.settings.connectObject(
-			'changed::show-indicator',
-			this.updateSettings.bind(this),
-			'changed::show-content-indicator',
+			'changed::indicator-display',
 			this.updateSettings.bind(this),
 			'changed::incognito',
 			this.updateSettings.bind(this),
@@ -149,16 +147,22 @@ export class ClipboardIndicator extends PanelMenu.Button {
 
 	private set previewWidget(widget: St.Widget) {
 		this._previewWidget?.destroy();
-		widget.visible = this.ext.settings.get_boolean('show-content-indicator');
 		this._previewWidget = widget;
 		this._box.add_child(widget);
+		this.updateSettings();
 	}
 
 	private updateSettings() {
-		const showIconIndicator = this.ext.settings.get_boolean('show-indicator');
-		const showContentIndicator = this.ext.settings.get_boolean('show-content-indicator');
+		const indicatorDisplay = this.ext.settings.get_enum('indicator-display');
+		const showContentIndicator =
+			indicatorDisplay === IndicatorDisplay.ClipboardContentOnly ||
+			indicatorDisplay === IndicatorDisplay.IconAndClipboardContent;
+		const showIconIndicator =
+			indicatorDisplay === IndicatorDisplay.IconOnly ||
+			indicatorDisplay === IndicatorDisplay.IconAndClipboardContent ||
+			(showContentIndicator && !this._previewWidget);
 
-		this.visible = showIconIndicator || showContentIndicator;
+		this.visible = indicatorDisplay !== IndicatorDisplay.Hidden;
 		this._icon.visible = showIconIndicator;
 		if (this._previewWidget) this._previewWidget.visible = showContentIndicator;
 		this.incognito = this.ext.settings.get_boolean('incognito');


### PR DESCRIPTION
<img width="151" height="52" alt="image" src="https://github.com/user-attachments/assets/a31e1399-9f7a-47f4-ace5-180b3ece6604" />

This fixes issue #82. 

Now it hides the whole panel indicator only when both the icon and content preview are disabled.