### PR TITLE
Avoided redundant work in clipboard hot paths to improve extension speed

### DIFF
--- a/src/lib/database/memory.ts
+++ b/src/lib/database/memory.ts
@@ -110,22 +110,19 @@ export class MemoryDatabase implements Database {
 
 	public async deleteOldest(offset: number, olderThanMinutes: number): Promise<number[]> {
 		const entries = await this.entries();
-		let deleted = entries
-			.filter((e) => !(e.pinned || e.tag))
-			.map((e) => e.id)
-			.slice(offset);
+		const unprotected = entries.filter((e) => !(e.pinned || e.tag));
+		const deleted = unprotected.slice(offset).map((e) => e.id);
 
 		if (olderThanMinutes > 0) {
 			const now = GLib.DateTime.new_now_utc();
 			const olderThan = now.add_minutes(-olderThanMinutes)!;
-			deleted = [
-				...new Set([
-					...deleted,
-					...entries
-						.filter((e) => !(e.pinned || e.tag) && e.datetime.compare(olderThan) < 0)
-						.map((e) => e.id),
-				]),
-			];
+			const deletedIds = new Set(deleted);
+			for (const entry of unprotected) {
+				if (!deletedIds.has(entry.id) && entry.datetime.compare(olderThan) < 0) {
+					deletedIds.add(entry.id);
+					deleted.push(entry.id);
+				}
+			}
 		}
 
 		for (const id of deleted) {

--- a/src/lib/misc/clipboard.ts
+++ b/src/lib/misc/clipboard.ts
@@ -18,6 +18,10 @@ Gio._promisify(Gio.File.prototype, 'replace_contents_async');
 Gio._promisify(Gio.MemoryOutputStream.prototype, 'splice_async');
 Gio._promisify(Meta.SelectionSource.prototype, 'read_async');
 
+const Utf8Decoder = new TextDecoder();
+const Utf8Encoder = new TextEncoder();
+const GraphemeSegmenter = new Intl.Segmenter();
+
 const MimeTypes = {
 	Text: ['text/plain;charset=utf-8', 'UTF8_STRING', 'text/plain', 'STRING'],
 	Image: ['image/png', 'image/jxl', 'image/webp', 'image/avif', 'image/jpeg'],
@@ -49,6 +53,12 @@ function contentChecksum(content: ClipboardContent): string | null {
 			return GLib.compute_checksum_for_string(GLib.ChecksumType.MD5, s, s.length);
 		}
 	}
+}
+
+function hasMoreGraphemes(text: string, max: number): boolean {
+	const iterator = GraphemeSegmenter.segment(text)[Symbol.iterator]();
+	for (let i = 0; i < max; i++) iterator.next();
+	return iterator.next().value !== undefined;
 }
 
 @registerClass({
@@ -118,7 +128,7 @@ export class ClipboardManager extends GObject.Object {
 		// File
 		if (content.type === ContentType.File) {
 			const s = `${FileOperation.Copy}\n${content.paths.join('\n')}`;
-			const bytes = new TextEncoder().encode(s);
+			const bytes = Utf8Encoder.encode(s);
 			this.clipboard.set_content(St.ClipboardType.CLIPBOARD, MimeTypes.File[0], bytes);
 			return;
 		}
@@ -210,9 +220,8 @@ export class ClipboardManager extends GObject.Object {
 		}
 	}
 
-	private shouldSave(selectionSource: Meta.SelectionSource): boolean {
+	private shouldSave(mimeTypes: readonly string[]): boolean {
 		// Mime Type
-		const mimeTypes = selectionSource.get_mimetypes();
 		if (MimeTypes.Sensitive.some((value) => mimeTypes.includes(value))) {
 			return false;
 		}
@@ -236,7 +245,8 @@ export class ClipboardManager extends GObject.Object {
 			if (selectionSource === null) return;
 			if (selectionType !== Meta.SelectionType.SELECTION_CLIPBOARD) return;
 
-			const content = await this.getContent(selectionSource);
+			const mimeTypes = selectionSource.get_mimetypes();
+			const content = await this.getContent(selectionSource, mimeTypes);
 			if (!content) return;
 
 			const checksum = contentChecksum(content);
@@ -261,7 +271,7 @@ export class ClipboardManager extends GObject.Object {
 			// Check if history should be saved after setting the previous clipboard item.
 			// This ensures that content copied in incognito mode is not saved to history
 			// after copying an item after exiting incognito mode.
-			if (!this.shouldSave(selectionSource)) return;
+			if (!this.shouldSave(mimeTypes)) return;
 
 			const res = await this.convertContent(content);
 			if (!res) return;
@@ -276,7 +286,10 @@ export class ClipboardManager extends GObject.Object {
 		}
 	}
 
-	private async getContent(selectionSource: Meta.SelectionSource): Promise<ClipboardContent | null> {
+	private async getContent(
+		selectionSource: Meta.SelectionSource,
+		mimeTypes: readonly string[],
+	): Promise<ClipboardContent | null> {
 		async function getBytes(mimeType: string): Promise<Uint8Array<ArrayBufferLike>> {
 			const source = await selectionSource.read_async(mimeType, null);
 			const out = Gio.MemoryOutputStream.new_resizable();
@@ -288,8 +301,6 @@ export class ClipboardManager extends GObject.Object {
 			);
 			return out.steal_as_bytes().toArray();
 		}
-
-		const mimeTypes = selectionSource.get_mimetypes();
 
 		// Image
 		const imageMimeType = MimeTypes.Image.find((value) => mimeTypes.includes(value));
@@ -308,7 +319,7 @@ export class ClipboardManager extends GObject.Object {
 		const fileMimeType = MimeTypes.File.find((value) => mimeTypes.includes(value));
 		if (fileMimeType) {
 			const bytes = await getBytes(fileMimeType);
-			const text = new TextDecoder().decode(bytes).trim();
+			const text = Utf8Decoder.decode(bytes).trim();
 			if (text) {
 				const files = text
 					.split('\n')
@@ -329,7 +340,7 @@ export class ClipboardManager extends GObject.Object {
 		const textMimeType = MimeTypes.Text.find((value) => mimeTypes.includes(value));
 		if (textMimeType) {
 			const bytes = await getBytes(textMimeType);
-			const text = new TextDecoder().decode(bytes);
+			const text = Utf8Decoder.decode(bytes);
 			if (text && text.trim()) {
 				return { type: ContentType.Text, text };
 			} else {
@@ -354,10 +365,8 @@ export class ClipboardManager extends GObject.Object {
 			}
 
 			// Character
-			const iterator = new Intl.Segmenter().segment(trimmed)[Symbol.iterator]();
 			const maxCharacters = this.ext.settings.get_child('character-item').get_int('max-characters');
-			for (let i = 0; i < maxCharacters; i++) iterator.next();
-			if (!iterator.next().value) {
+			if (!hasMoreGraphemes(trimmed, maxCharacters)) {
 				return [ItemType.Character, content.text, null];
 			}
 

--- a/src/lib/ui/clipboardScrollContainer.ts
+++ b/src/lib/ui/clipboardScrollContainer.ts
@@ -120,21 +120,22 @@ export class ClipboardScrollContainer extends St.BoxLayout {
 	public addItem(item: ClipboardItem): void {
 		this.insertOrMoveItem(item);
 
-		if (this._lastQuery) {
-			item.search(this._lastQuery);
-		}
-
 		// Move item when datetime changes
-		item.entry.connect('notify::datetime', () => this.insertOrMoveItem(item));
+		item.entry.connect('notify::datetime', () => this.insertOrMoveItem(item, false));
 
 		// Delete item when deleted
 		item.entry.connect('delete', () => this.removeItem(item));
 
-		// Update search when entry changes
-		item.entry.connect('notify', () => this.updateSearch(item));
+		// Update search only when properties used by search can change.
+		item.entry.connect('notify::content', () => this.updateSearch(item));
+		item.entry.connect('notify::pinned', () => this.updateSearch(item));
+		item.entry.connect('notify::tag', () => this.updateSearch(item));
+		item.entry.connect('notify::type', () => this.updateSearch(item));
+		item.entry.connect('notify::metadata', () => this.updateSearch(item));
+		item.entry.connect('notify::title', () => this.updateSearch(item));
 	}
 
-	private insertOrMoveItem(item: ClipboardItem): void {
+	private insertOrMoveItem(item: ClipboardItem, search: boolean = true): void {
 		this.removePseudoclasses();
 
 		if (item.get_parent() === this) this.remove_child(item);
@@ -152,8 +153,11 @@ export class ClipboardScrollContainer extends St.BoxLayout {
 			this.add_child(item);
 		}
 
-		this.updateSearch(item);
-		this.updateVisible();
+		if (search && this._lastQuery) {
+			this.updateSearch(item);
+		} else {
+			this.updateVisible();
+		}
 	}
 
 	public clearItems(): void {

--- a/src/lib/ui/components/contentInfo.ts
+++ b/src/lib/ui/components/contentInfo.ts
@@ -14,6 +14,9 @@ import { Icon, loadIcon } from '../../common/icons.js';
 import { TextCountMode } from '../../common/settings.js';
 import { FileType } from './contentPreview.js';
 
+const GraphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+const WordSegmenter = new Intl.Segmenter(undefined, { granularity: 'word' });
+
 function formatBytes(bytes: number): [string, string] {
 	const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 	const exp = Math.floor(Math.log10(bytes) / 3);
@@ -34,6 +37,14 @@ function formatTime(seconds: number): string {
 	res += _('%ds').format(s);
 
 	return res;
+}
+
+function countLines(text: string): number {
+	let count = 1;
+	for (let i = 0; i < text.length; i++) {
+		if (text[i] === '\n') count++;
+	}
+	return count;
 }
 
 @registerClass()
@@ -100,20 +111,18 @@ export class TextInfo extends ContentInfo {
 	private updateCount() {
 		if (this._textCountMode === TextCountMode.Characters) {
 			let count = 0;
-			const segments = new Intl.Segmenter(undefined, { granularity: 'grapheme' }).segment(this._text);
-			for (const _segment of segments) count++;
+			for (const _segment of GraphemeSegmenter.segment(this._text)) count++;
 
 			this._countLabel.text = ngettext('%d char', '%d chars', count).format(count);
 		} else if (this._textCountMode === TextCountMode.Words) {
 			let count = 0;
-			const segments = new Intl.Segmenter(undefined, { granularity: 'word' }).segment(this._text);
-			for (const segment of segments) {
+			for (const segment of WordSegmenter.segment(this._text)) {
 				if (segment.isWordLike) count++;
 			}
 
 			this._countLabel.text = ngettext('%d word', '%d words', count).format(count);
 		} else if (this._textCountMode === TextCountMode.Lines) {
-			const count = this._text.split('\n').length;
+			const count = countLines(this._text);
 			this._countLabel.text = ngettext('%d line', '%d lines', count).format(count);
 		}
 	}

--- a/src/lib/ui/searchEntry.ts
+++ b/src/lib/ui/searchEntry.ts
@@ -15,10 +15,11 @@ import { Icon, loadIcon } from '../common/icons.js';
 import { ClipboardEntry } from '../database/database.js';
 import { TagsItem } from './components/tagsItem.js';
 
+const SearchCollator = new Intl.Collator(undefined, { sensitivity: 'base' });
+
 function localeContains(text: string, query: string): boolean {
-	const collator = new Intl.Collator(undefined, { sensitivity: 'base' });
 	for (let offset = 0; offset <= text.length - query.length; offset++) {
-		const comparison = collator.compare(text.substring(offset, offset + query.length), query);
+		const comparison = SearchCollator.compare(text.substring(offset, offset + query.length), query);
 		if (comparison === 0) return true;
 	}
 	return false;
@@ -85,9 +86,9 @@ export class SearchQuery extends GObject.Object {
 		if (this.change === SearchChange.LessStrict && state) return true;
 		if (this.change === SearchChange.MoreStrict && !state) return false;
 
-		// Include entry title in search texts
-		const searchTexts = entry.title ? [...text, entry.title] : text;
-		return this.matchesProperties(entry.pinned, entry.tag, entry.type) && this.matchesQuery(...searchTexts);
+		if (!this.matchesProperties(entry.pinned, entry.tag, entry.type)) return false;
+		if (this.matchesQuery(...text)) return true;
+		return entry.title ? this.matchesQuery(entry.title) : false;
 	}
 
 	public withChange(change: SearchChange): SearchQuery {
@@ -417,6 +418,7 @@ export class SearchEntry extends St.Entry {
 	get searchQuery(): SearchQuery {
 		const excludePinned = this.ext.settings.get_boolean('exclude-pinned');
 		const excludeTagged = this.ext.settings.get_boolean('exclude-tagged');
+		const query = this.text;
 
 		let change: SearchChange;
 		if (!this._prevSearch) {
@@ -424,9 +426,9 @@ export class SearchEntry extends St.Entry {
 		} else {
 			// Query
 			let queryChange: SearchChange;
-			if (this.text === this._prevSearch.query) queryChange = SearchChange.Same;
-			else if (this.text.includes(this._prevSearch.query)) queryChange = SearchChange.MoreStrict;
-			else if (this._prevSearch.query.includes(this.text)) queryChange = SearchChange.LessStrict;
+			if (query === this._prevSearch.query) queryChange = SearchChange.Same;
+			else if (query.includes(this._prevSearch.query)) queryChange = SearchChange.MoreStrict;
+			else if (this._prevSearch.query.includes(query)) queryChange = SearchChange.LessStrict;
 			else queryChange = SearchChange.Different;
 
 			change = queryChange;
@@ -475,7 +477,7 @@ export class SearchEntry extends St.Entry {
 				change = change === SearchChange.Same || change === typeChange ? typeChange : SearchChange.Different;
 		}
 
-		return new SearchQuery(change, this.text, this.pinned, excludePinned, this.tag, excludeTagged, this.type);
+		return new SearchQuery(change, query, this.pinned, excludePinned, this.tag, excludeTagged, this.type);
 	}
 
 	private search() {


### PR DESCRIPTION
Made copyous faster by making the changes below:
  - Reused expensive Intl.Collator, Intl.Segmenter, TextDecoder, and TextEncoder instances instead of recreating them repeatedly in src/lib/ui/searchEntry.ts:18, src/lib/ui/components/contentInfo.ts:17, and src/
    lib/misc/clipboard.ts:21.
  - Avoided duplicate clipboard MIME-type reads during clipboard ownership changes in src/lib/misc/clipboard.ts:248.
  - Stopped rerunning item search on irrelevant entry notifications like datetime changes, while keeping search updates for content/tag/type/title/metadata changes in src/lib/ui/clipboardScrollContainer.ts:123.
  - Reduced temporary arrays in search title matching and database pruning in src/lib/ui/searchEntry.ts:84 and src/lib/database/memory.ts:111.
  - Replaced line counting via split('\n') with a simple scan to avoid allocating an array for large text in src/lib/ui/components/contentInfo.ts:42.

I noticed a significant improvement when testing it.