### PR TITLE
fix: prevent grab race condition during close animation

### DIFF
--- a/src/lib/ui/clipboardDialog.ts
+++ b/src/lib/ui/clipboardDialog.ts
@@ -255,6 +255,7 @@ class ClipboardDialogFooter extends St.BoxLayout {
 export class ClipboardDialog extends St.Widget {
 	private _grab: Clutter.Grab | null = null;
 	private _open: boolean = false;
+	private _closing: boolean = false;
 	private _updateCursor: boolean = true;
 	private _nextCursor: [number, number] | null = null;
 	private _cursor: [number, number] | null = null;
@@ -419,7 +420,7 @@ export class ClipboardDialog extends St.Widget {
 	}
 
 	public open() {
-		if (this.opened) return;
+		if (this.opened || this._closing) return;
 
 		this._updateCursor = false;
 		this._nextCursor = this._cursor;
@@ -485,6 +486,7 @@ export class ClipboardDialog extends St.Widget {
 	public close() {
 		if (!this.opened) return;
 
+		this._closing = true;
 		this.opened = false;
 		this._updateCursor = true;
 		this._clipboardItemMenu.close();
@@ -526,6 +528,7 @@ export class ClipboardDialog extends St.Widget {
 			onComplete: () => {
 				Main.popModal(this._grab);
 				this._grab = null;
+				this._closing = false;
 				this.hide();
 				global.compositor.enable_unredirect();
 			},


### PR DESCRIPTION
Add `_closing` flag to block `open()` calls during the 150ms close animation. Without this guard, rapid shortcut presses could trigger `pushModal()` before `popModal()` from the previous close animation ran, corrupting Mutter's keyboard state machine and causing all modifier keys (Meta, Ctrl, Alt) to stop working.