### PR TITLE
🚀 perf: ⚡ perf: optimize cold-boot startup and dialog open path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ $(DIST_DIR)/css/template-%.css: \
 		resources/css/template.scss scripts/template/postcss.config.cjs \
 		resources/css/themes/default/_*.scss resources/css/themes/default/widgets | $(DIST_DIR)
 	@mkdir -p $(DIST_DIR)/css
-	VARIANT=$* pnpm exec postcss $< --config scripts/template | pnpm exec sass --no-source-map --stdin $@
+	VARIANT=$* ./node_modules/.bin/postcss $< --config scripts/template | ./node_modules/.bin/sass --no-source-map --stdin $@
 
 CSS := $(THEME_CSS) $(DIST_DIR)/css/template-dark.css $(DIST_DIR)/css/template-light.css
 

--- a/PLANO_MELHORIAS_E_BACKUP.md
+++ b/PLANO_MELHORIAS_E_BACKUP.md
@@ -1,0 +1,156 @@
+# Plano de melhorias e seguranca do historico
+
+## Estado atual
+
+- Fork atualizado com `upstream/main`.
+- Conflitos resolvidos sem remover as otimizacoes locais de cold boot, bulk load, lazy layout e prewarm.
+- Mudancas estao prontas para commit local.
+- Nao publicar nem testar instalacao nova sem backup do historico salvo.
+
+## Backup obrigatorio antes de novos testes
+
+O historico do Copyous pode estar em SQLite ou JSON. Quando `database-location` esta vazio, o padrao fica em:
+
+- `${XDG_DATA_HOME:-$HOME/.local/share}/copyous@boerdereinar.dev/clipboard.db`
+- `${XDG_DATA_HOME:-$HOME/.local/share}/copyous@boerdereinar.dev/clipboard.json`
+
+Antes de rodar `make install`, `make launch`, trocar backend de banco, limpar historico ou testar migracoes:
+
+```bash
+BACKUP="$HOME/backup-copyous-$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$BACKUP"
+
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/copyous@boerdereinar.dev"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/copyous@boerdereinar.dev"
+
+cp -a "$DATA_DIR" "$BACKUP/data" 2>/dev/null || true
+cp -a "$CONFIG_DIR" "$BACKUP/config" 2>/dev/null || true
+dconf dump /org/gnome/shell/extensions/copyous/ > "$BACKUP/dconf-copyous.ini"
+```
+
+Verificar se ha caminho customizado de banco:
+
+```bash
+gsettings get org.gnome.shell.extensions.copyous database-location
+gsettings get org.gnome.shell.extensions.copyous database-backend
+```
+
+Se `database-location` retornar um caminho real, copiar esse arquivo tambem:
+
+```bash
+cp -a "/caminho/customizado/clipboard.db" "$BACKUP/"
+cp -a "/caminho/customizado/clipboard.json" "$BACKUP/"
+```
+
+Conferencia minima do backup:
+
+```bash
+find "$BACKUP" -maxdepth 3 -type f -print
+```
+
+Regra: se o backup nao contem `clipboard.db`, `clipboard.json` ou um caminho customizado confirmado, parar e investigar antes de continuar.
+
+## Plano de melhorias
+
+1. Fechar o merge atual
+   - Commitar o merge local.
+   - Rodar `tsc`, `eslint`, `prettier`, `make check-pot` e `make check-po`.
+   - Testar manualmente abrir, fechar, pesquisar, copiar, colar e reabrir rapido.
+
+2. Proteger o historico
+   - Nunca alterar backend sem backup.
+   - Testar migracao entre SQLite e JSON usando copia do banco.
+   - Confirmar que `clear-history` nao afeta itens pinned/tagged indevidamente.
+
+3. Corrigir riscos pos-merge
+   - Garantir que `_closing` volta para `false` se o dialogo for destruido durante animacao.
+   - Cancelar callbacks idle pendentes em `disable()`.
+   - Validar `preWarm()` com historico grande.
+
+4. Otimizar carregamento inicial
+   - Medir tempo de `enable()` e `initEntryTracker()`.
+   - Carregar historico em lotes se houver muitos itens.
+   - Evitar previews pesados antes da primeira abertura real.
+
+5. Otimizar busca
+   - Cachear texto pesquisavel por item.
+   - Invalidar cache apenas em `content`, `title`, `metadata`, `type`, `tag` e `pinned`.
+   - Evitar reprocessar todos os itens quando a busca ficar apenas mais restritiva.
+
+6. Reduzir vazamentos
+   - Auditar `connect()` sem desconexao em itens, menus e banco.
+   - Garantir que `loadItems()` nao duplica sinais.
+   - Verificar destruicao de itens removidos.
+
+7. Testar UI e edge cases
+   - Orientacao vertical e horizontal.
+   - Scrollbar ligada/desligada.
+   - `show-at-pointer` e `show-at-cursor`.
+   - RTL.
+   - Busca por titulo customizado.
+   - Filtros pinned, tagged e tipo.
+   - Abrir durante animacao de fechamento.
+
+8. Automatizar validacao
+   - Criar `make validate`.
+   - Incluir typecheck, lint, prettier, check-pot e check-po.
+   - Documentar checklist manual antes de release.
+
+9. Performance futura
+   - Adicionar logs opcionais de tempo em modo debug.
+   - Medir cold boot, primeira abertura, busca com 500 itens e limpeza de historico.
+   - Manter apenas otimizacoes com ganho mensuravel.
+
+## Ordem recomendada
+
+1. Backup local.
+2. Commit do merge atual.
+3. Validacao estatica.
+4. Teste manual com backup ja feito.
+5. Correcoes de `_closing`, idle callbacks e destruicao.
+6. Otimizacoes de busca e carregamento.
+7. Automacao final.
+
+## Applied work log
+
+- Local backup created before code changes:
+  `/home/talesam/Backups/copyous-20260708-225934`
+- Backup includes clipboard database, config, cache, dconf dump, backend/location notes and SHA256 manifest.
+- Applied low-risk lifecycle fixes:
+  cancel pending idle callbacks, guard entry tracker init, finish dialog close on destroy.
+- Applied first-open performance fixes:
+  load history in batches, prewarm visible items, defer file/link previews.
+- Applied search performance fixes:
+  cache searchable text per item, invalidate cache only when entry content/title/metadata changes.
+- Applied UI fix:
+  edit dialog text area is smaller, padded, and uses a thin focus border instead of the oversized ring.
+- Applied packaging fix:
+  split child GSettings schemas into one file per schema ID to satisfy EGO package validation.
+- Validation run:
+  `tsc --noEmit`, `eslint`, `prettier --check`, theme SCSS compile, `tsc --sourceMap --sourceRoot src`, schema dry-run, `make check-pot`, `make check-po`, `make build`.
+- Build note:
+  `pnpm@11.3.0` needs `pnpm_config_verify_deps_before_run=false` with the current `node_modules` generated by pnpm 10.
+- Shexli note:
+  EGO-P-004 schema errors fixed; remaining `shexli` output is warnings/manual review for existing lifecycle/clipboard patterns.
+
+## Latest VM test fixes
+
+- Fixed item list alignment after empty/search states:
+  items now reset the list alignment to start whenever at least one clipboard item is visible.
+- Improved edit dialog:
+  larger text area, thin border, top-aligned multiline content, and direct text focus when the dialog opens.
+- Added `keep-pinned` clipboard history mode:
+  color/tag no longer behaves like a pinned item in the default fork mode.
+- Kept the old `keep-pinned-and-tagged` mode available for users who want tags to preserve history items.
+- Changed default `protect-tagged` to `false`.
+- Updated gettext POT/PO catalogs after the new UI strings.
+- VM install:
+  system extension replaced at `/usr/share/gnome-shell/extensions/copyous@boerdereinar.dev`.
+- VM settings applied for testing:
+  `clipboard-history='keep-pinned'`, `protect-tagged=false`.
+- VM package hash:
+  `0aa225c3a12b93b9f91baff4961c4bba4bee2de11702abfe6af8587a323df428`.
+- Validation run after latest fixes:
+  `tsc --noEmit`, `eslint`, `prettier --check`, schema dry-run, `make check-pot`, `make check-po`, `make -B build`.
+- Remaining non-blocking VM log:
+  missing local `highlight.min.js`; extension still reports `State: ACTIVE`.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+allowBuilds:
+    '@parcel/watcher': true
+    esbuild: true
+
+onlyBuiltDependencies:
+    - '@parcel/watcher'
+    - esbuild

--- a/resources/css/themes/default/widgets/_edit-dialog.scss
+++ b/resources/css/themes/default/widgets/_edit-dialog.scss
@@ -2,8 +2,28 @@
 .clipboard-item-edit-dialog {
 	width: 35em;
 
+	.modal-dialog-content-box {
+		margin: $base_padding * 0.5 $base_padding * 1.5 $base_padding;
+		spacing: $base_padding * 1.25;
+		max-width: none;
+	}
+
+	.message-dialog-content {
+		spacing: $base_padding * 1.25;
+	}
+
 	.clipboard-item-edit-dialog-entry {
-		height: 16em;
+		height: 13em;
+		padding: 0;
+		background-color: $card_bg_color;
+		border: 1px solid $card_shadow_border_color;
+		border-radius: $alert_radius;
+		box-shadow: none;
+
+		&:focus {
+			border-color: -st-accent-color;
+			box-shadow: none;
+		}
 
 		&.monospace {
 			@extend %monospace;
@@ -11,8 +31,14 @@
 		}
 
 		.multiline-scrollview {
+			padding: $base_padding;
+
 			.multiline-box {
-				padding-right: $base_padding;
+				padding-right: 0;
+			}
+
+			StScrollBar {
+				padding: $base_padding * 0.5 0 $base_padding * 0.5 $base_padding * 0.25;
 			}
 		}
 	}

--- a/resources/po/de.po
+++ b/resources/po/de.po
@@ -8,11 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-<<<<<<< Updated upstream
-"POT-Creation-Date: 2026-04-26 12:23-0500\n"
-=======
-"POT-Creation-Date: 2026-07-09 00:11-0300\n"
->>>>>>> Stashed changes
+"POT-Creation-Date: 2026-07-09 00:47-0300\n"
 "PO-Revision-Date: 2026-03-26 22:19+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -221,7 +217,7 @@ msgstr "Wählen Sie aus, welche Typen zulässig sind"
 #: src/lib/preferences/dependencies/dependencies.ts:224
 #: src/lib/preferences/general/appExclusionSettings.ts:171
 #: src/lib/preferences/shortcuts/shortcutRow.ts:131
-#: src/lib/ui/components/editDialog.ts:314 src/lib/ui/indicator.ts:47
+#: src/lib/ui/components/editDialog.ts:315 src/lib/ui/indicator.ts:47
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -352,7 +348,7 @@ msgid "Edit Action"
 msgstr "Aktion editieren"
 
 #: src/lib/preferences/actions/actionDialog.ts:662
-#: src/lib/ui/components/editDialog.ts:321
+#: src/lib/ui/components/editDialog.ts:322
 msgid "Save"
 msgstr "Speichern"
 
@@ -1857,45 +1853,6 @@ msgstr "Zwischenablage ist leer"
 msgid "No Items Found"
 msgstr "Keine Elemente gefunden"
 
-<<<<<<< Updated upstream
-#: src/lib/ui/searchEntry.ts:150
-msgid "__All"
-msgstr "__Alle"
-
-#: src/lib/ui/searchEntry.ts:154
-msgid "__Text"
-msgstr "__Text"
-
-#: src/lib/ui/searchEntry.ts:155
-msgid "__Code"
-msgstr "__Code"
-
-#: src/lib/ui/searchEntry.ts:156
-msgid "__Image"
-msgstr "__Bild"
-
-#: src/lib/ui/searchEntry.ts:157
-msgid "__File"
-msgstr "__Datei"
-
-#: src/lib/ui/searchEntry.ts:158
-msgid "File__s"
-msgstr "Dateie__n"
-
-#: src/lib/ui/searchEntry.ts:159
-msgid "__Link"
-msgstr "__Link"
-
-#: src/lib/ui/searchEntry.ts:160
-msgid "C__haracter"
-msgstr "Z__eichen"
-
-#: src/lib/ui/searchEntry.ts:161
-msgid "Colo__r"
-msgstr "Fa__rbe"
-
-#: src/lib/ui/searchEntry.ts:273
-=======
 #: src/lib/ui/searchEntry.ts:154
 msgid "__All"
 msgstr "__Alle"
@@ -1933,7 +1890,6 @@ msgid "Colo__r"
 msgstr "Fa__rbe"
 
 #: src/lib/ui/searchEntry.ts:277
->>>>>>> Stashed changes
 msgid "Type to search"
 msgstr "Zum Suchen tippen"
 

--- a/resources/po/de.po
+++ b/resources/po/de.po
@@ -8,7 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
+<<<<<<< Updated upstream
 "POT-Creation-Date: 2026-04-26 12:23-0500\n"
+=======
+"POT-Creation-Date: 2026-07-09 00:11-0300\n"
+>>>>>>> Stashed changes
 "PO-Revision-Date: 2026-03-26 22:19+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -126,8 +130,8 @@ msgstr "Kopierte Farbe"
 #: src/lib/preferences/general/feedbackSettings.ts:259
 #: src/lib/preferences/general/feedbackSettings.ts:308
 #: src/lib/preferences/shortcuts/itemShortcuts.ts:39
-#: src/lib/ui/components/editDialog.ts:217
-#: src/lib/ui/components/editDialog.ts:244
+#: src/lib/ui/components/editDialog.ts:225
+#: src/lib/ui/components/editDialog.ts:252
 msgid "None"
 msgstr "Keine"
 
@@ -156,7 +160,7 @@ msgstr "Code"
 #: src/lib/preferences/actions/actionDialog.ts:177
 #: src/lib/preferences/actions/actionDialog.ts:370
 #: src/lib/preferences/customization/items/fileItemCustomization.ts:79
-#: src/lib/ui/items/imageItem.ts:38
+#: src/lib/ui/items/imageItem.ts:37
 msgid "Image"
 msgstr "Bild"
 
@@ -170,7 +174,7 @@ msgstr "Datei"
 #: src/lib/preferences/actions/actionDefaults.ts:148
 #: src/lib/preferences/actions/actionDialog.ts:179
 #: src/lib/preferences/actions/actionDialog.ts:376
-#: src/lib/ui/items/filesItem.ts:140
+#: src/lib/ui/items/filesItem.ts:139
 msgid "Files"
 msgstr "Dateien"
 
@@ -178,7 +182,7 @@ msgstr "Dateien"
 #: src/lib/preferences/actions/actionDialog.ts:180
 #: src/lib/preferences/actions/actionDialog.ts:379
 #: src/lib/preferences/customization/items/linkItemCustomization.ts:45
-#: src/lib/ui/items/linkItem.ts:303
+#: src/lib/ui/items/linkItem.ts:304
 msgid "Link"
 msgstr "Link"
 
@@ -217,7 +221,7 @@ msgstr "Wählen Sie aus, welche Typen zulässig sind"
 #: src/lib/preferences/dependencies/dependencies.ts:224
 #: src/lib/preferences/general/appExclusionSettings.ts:171
 #: src/lib/preferences/shortcuts/shortcutRow.ts:131
-#: src/lib/ui/components/editDialog.ts:306 src/lib/ui/indicator.ts:47
+#: src/lib/ui/components/editDialog.ts:314 src/lib/ui/indicator.ts:47
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -348,7 +352,7 @@ msgid "Edit Action"
 msgstr "Aktion editieren"
 
 #: src/lib/preferences/actions/actionDialog.ts:662
-#: src/lib/ui/components/editDialog.ts:313
+#: src/lib/ui/components/editDialog.ts:321
 msgid "Save"
 msgstr "Speichern"
 
@@ -1510,7 +1514,7 @@ msgstr ""
 "Ihr System neu starten, sich abmelden oder herunterfahren"
 
 #: src/lib/preferences/general/historySettings.ts:137
-#: src/lib/ui/clipboardDialog.ts:130 src/lib/ui/clipboardDialog.ts:235
+#: src/lib/ui/clipboardDialog.ts:134 src/lib/ui/clipboardDialog.ts:239
 #: src/lib/ui/indicator.ts:54
 msgid "Clear"
 msgstr "Leeren"
@@ -1518,6 +1522,10 @@ msgstr "Leeren"
 #: src/lib/preferences/general/historySettings.ts:137
 msgid "Keep All"
 msgstr "Alle behalten"
+
+#: src/lib/preferences/general/historySettings.ts:137
+msgid "Keep Pinned"
+msgstr ""
 
 #: src/lib/preferences/general/historySettings.ts:137
 msgid "Keep Pinned/Tagged"
@@ -1776,7 +1784,7 @@ msgstr "Fehlende Datei"
 msgid "Error"
 msgstr "Fehler"
 
-#: src/lib/ui/components/editDialog.ts:269
+#: src/lib/ui/components/editDialog.ts:277
 msgid "Edit Clipboard Item"
 msgstr "Clipboard-Element bearbeiten"
 
@@ -1793,22 +1801,22 @@ msgid "Are you sure you want to clear your clipboard history?"
 msgstr "Möchten Sie wirklich den Verlauf Ihrer Zwischenablage löschen?"
 
 #: src/lib/ui/indicator.ts:43
-msgid "Clear Pinned/Tagged Items"
-msgstr "Fixierte/markierte Elemente löschen"
+msgid "Clear Pinned Items"
+msgstr ""
 
-#: src/lib/ui/indicator.ts:102
+#: src/lib/ui/indicator.ts:99
 msgid "Incognito Mode"
 msgstr "Inkognito-Modus"
 
-#: src/lib/ui/indicator.ts:105
+#: src/lib/ui/indicator.ts:102
 msgid "Clear History"
 msgstr "Verlauf löschen"
 
-#: src/lib/ui/indicator.ts:106
+#: src/lib/ui/indicator.ts:103
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: src/lib/ui/indicator.ts:199
+#: src/lib/ui/indicator.ts:196
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -1819,14 +1827,14 @@ msgstr[1] "%d Dateien"
 msgid "Char"
 msgstr "Char"
 
-#: src/lib/ui/items/filesItem.ts:120
+#: src/lib/ui/items/filesItem.ts:119
 #, javascript-format
 msgid "%d more file"
 msgid_plural "%d more files"
 msgstr[0] "%d mehr Dateien"
 msgstr[1] "%d mehre Dateien"
 
-#: src/lib/ui/items/filesItem.ts:121
+#: src/lib/ui/items/filesItem.ts:120
 #, javascript-format
 msgid "%d file"
 msgid_plural "%d files"
@@ -1849,6 +1857,7 @@ msgstr "Zwischenablage ist leer"
 msgid "No Items Found"
 msgstr "Keine Elemente gefunden"
 
+<<<<<<< Updated upstream
 #: src/lib/ui/searchEntry.ts:150
 msgid "__All"
 msgstr "__Alle"
@@ -1886,6 +1895,45 @@ msgid "Colo__r"
 msgstr "Fa__rbe"
 
 #: src/lib/ui/searchEntry.ts:273
+=======
+#: src/lib/ui/searchEntry.ts:154
+msgid "__All"
+msgstr "__Alle"
+
+#: src/lib/ui/searchEntry.ts:158
+msgid "__Text"
+msgstr "__Text"
+
+#: src/lib/ui/searchEntry.ts:159
+msgid "__Code"
+msgstr "__Code"
+
+#: src/lib/ui/searchEntry.ts:160
+msgid "__Image"
+msgstr "__Bild"
+
+#: src/lib/ui/searchEntry.ts:161
+msgid "__File"
+msgstr "__Datei"
+
+#: src/lib/ui/searchEntry.ts:162
+msgid "File__s"
+msgstr "Dateie__n"
+
+#: src/lib/ui/searchEntry.ts:163
+msgid "__Link"
+msgstr "__Link"
+
+#: src/lib/ui/searchEntry.ts:164
+msgid "C__haracter"
+msgstr "Z__eichen"
+
+#: src/lib/ui/searchEntry.ts:165
+msgid "Colo__r"
+msgstr "Fa__rbe"
+
+#: src/lib/ui/searchEntry.ts:277
+>>>>>>> Stashed changes
 msgid "Type to search"
 msgstr "Zum Suchen tippen"
 

--- a/resources/po/de.po
+++ b/resources/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-09 00:47-0300\n"
+"POT-Creation-Date: 2026-08-16 16:01-0300\n"
 "PO-Revision-Date: 2026-03-26 22:19+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -85,39 +85,39 @@ msgstr "Warnung deaktivieren"
 msgid "Failed to load JSON"
 msgstr "JSON konnte nicht geladen werden"
 
-#: src/lib/misc/notifications.ts:63 src/lib/misc/notifications.ts:114
+#: src/lib/misc/notifications.ts:63 src/lib/misc/notifications.ts:125
 msgid "Copied Text"
 msgstr "Kopierter Text"
 
-#: src/lib/misc/notifications.ts:98 src/lib/misc/notifications.ts:123
+#: src/lib/misc/notifications.ts:109 src/lib/misc/notifications.ts:134
 msgid "Copied Image"
 msgstr "Kopiertes Bild"
 
-#: src/lib/misc/notifications.ts:99 src/lib/misc/notifications.ts:129
+#: src/lib/misc/notifications.ts:110 src/lib/misc/notifications.ts:140
 #, javascript-format
 msgid "Size: %d×%d px"
 msgstr "Größe: %d×%d px"
 
-#: src/lib/misc/notifications.ts:118
+#: src/lib/misc/notifications.ts:129
 msgid "Copied Code"
 msgstr "Kopierter Code"
 
-#: src/lib/misc/notifications.ts:142
+#: src/lib/misc/notifications.ts:153
 #, javascript-format
 msgid "Copied %d File"
 msgid_plural "Copied %d Files"
 msgstr[0] "Kopiere %d Datei"
 msgstr[1] "Kopiere %d Dateien"
 
-#: src/lib/misc/notifications.ts:148
+#: src/lib/misc/notifications.ts:159
 msgid "Copied Link"
 msgstr "Kopierter Link"
 
-#: src/lib/misc/notifications.ts:152
+#: src/lib/misc/notifications.ts:163
 msgid "Copied Character"
 msgstr "Kopiertes Zeichen"
 
-#: src/lib/misc/notifications.ts:156
+#: src/lib/misc/notifications.ts:167
 msgid "Copied Color"
 msgstr "Kopierte Farbe"
 
@@ -1736,47 +1736,47 @@ msgstr "Tastenkürzel deaktivieren"
 msgid "Disabled"
 msgstr "Deaktiviert"
 
-#: src/lib/ui/components/contentInfo.ts:32
+#: src/lib/ui/components/contentInfo.ts:35
 #, javascript-format
 msgid "%dh"
 msgstr "%dh"
 
-#: src/lib/ui/components/contentInfo.ts:33
+#: src/lib/ui/components/contentInfo.ts:36
 #, javascript-format
 msgid "%dm"
 msgstr "%dm"
 
-#: src/lib/ui/components/contentInfo.ts:34
+#: src/lib/ui/components/contentInfo.ts:37
 #, javascript-format
 msgid "%ds"
 msgstr "%ds"
 
-#: src/lib/ui/components/contentInfo.ts:106
+#: src/lib/ui/components/contentInfo.ts:116
 #, javascript-format
 msgid "%d char"
 msgid_plural "%d chars"
 msgstr[0] "%d Zeichen"
 msgstr[1] "%d Zeichen"
 
-#: src/lib/ui/components/contentInfo.ts:114
+#: src/lib/ui/components/contentInfo.ts:123
 #, javascript-format
 msgid "%d word"
 msgid_plural "%d words"
 msgstr[0] "%d Wort"
 msgstr[1] "%d Wörter"
 
-#: src/lib/ui/components/contentInfo.ts:117
+#: src/lib/ui/components/contentInfo.ts:126
 #, javascript-format
 msgid "%d line"
 msgid_plural "%d lines"
 msgstr[0] "%d Zeile"
 msgstr[1] "%d Zeilen"
 
-#: src/lib/ui/components/contentInfo.ts:177
+#: src/lib/ui/components/contentInfo.ts:186
 msgid "Missing File"
 msgstr "Fehlende Datei"
 
-#: src/lib/ui/components/contentInfo.ts:189
+#: src/lib/ui/components/contentInfo.ts:198
 msgid "Error"
 msgstr "Fehler"
 

--- a/resources/po/fr.po
+++ b/resources/po/fr.po
@@ -8,11 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-<<<<<<< Updated upstream
-"POT-Creation-Date: 2026-04-26 12:23-0500\n"
-=======
-"POT-Creation-Date: 2026-07-09 00:11-0300\n"
->>>>>>> Stashed changes
+"POT-Creation-Date: 2026-07-09 00:47-0300\n"
 "PO-Revision-Date: 2025-12-06 04:59+0100\n"
 "Last-Translator: Axel Haustant <noirbizarre@gmail.com>\n"
 "Language-Team: \n"
@@ -221,7 +217,7 @@ msgstr "Sélectionnez les types autorisés"
 #: src/lib/preferences/dependencies/dependencies.ts:224
 #: src/lib/preferences/general/appExclusionSettings.ts:171
 #: src/lib/preferences/shortcuts/shortcutRow.ts:131
-#: src/lib/ui/components/editDialog.ts:314 src/lib/ui/indicator.ts:47
+#: src/lib/ui/components/editDialog.ts:315 src/lib/ui/indicator.ts:47
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -352,7 +348,7 @@ msgid "Edit Action"
 msgstr "Modifier l'action"
 
 #: src/lib/preferences/actions/actionDialog.ts:662
-#: src/lib/ui/components/editDialog.ts:321
+#: src/lib/ui/components/editDialog.ts:322
 msgid "Save"
 msgstr "Enregistrer"
 
@@ -1862,45 +1858,6 @@ msgstr "Le presse-papiers est vide"
 msgid "No Items Found"
 msgstr "Aucun élément trouvé"
 
-<<<<<<< Updated upstream
-#: src/lib/ui/searchEntry.ts:150
-msgid "__All"
-msgstr "__Tout"
-
-#: src/lib/ui/searchEntry.ts:154
-msgid "__Text"
-msgstr "__Texte"
-
-#: src/lib/ui/searchEntry.ts:155
-msgid "__Code"
-msgstr "__Code"
-
-#: src/lib/ui/searchEntry.ts:156
-msgid "__Image"
-msgstr "__Image"
-
-#: src/lib/ui/searchEntry.ts:157
-msgid "__File"
-msgstr "__Fichier"
-
-#: src/lib/ui/searchEntry.ts:158
-msgid "File__s"
-msgstr "Fichier__s"
-
-#: src/lib/ui/searchEntry.ts:159
-msgid "__Link"
-msgstr "__Lien"
-
-#: src/lib/ui/searchEntry.ts:160
-msgid "C__haracter"
-msgstr "C__aractère"
-
-#: src/lib/ui/searchEntry.ts:161
-msgid "Colo__r"
-msgstr "Couleu__r"
-
-#: src/lib/ui/searchEntry.ts:273
-=======
 #: src/lib/ui/searchEntry.ts:154
 msgid "__All"
 msgstr "__Tout"
@@ -1938,7 +1895,6 @@ msgid "Colo__r"
 msgstr "Couleu__r"
 
 #: src/lib/ui/searchEntry.ts:277
->>>>>>> Stashed changes
 msgid "Type to search"
 msgstr "Tapez pour rechercher"
 

--- a/resources/po/fr.po
+++ b/resources/po/fr.po
@@ -8,7 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
+<<<<<<< Updated upstream
 "POT-Creation-Date: 2026-04-26 12:23-0500\n"
+=======
+"POT-Creation-Date: 2026-07-09 00:11-0300\n"
+>>>>>>> Stashed changes
 "PO-Revision-Date: 2025-12-06 04:59+0100\n"
 "Last-Translator: Axel Haustant <noirbizarre@gmail.com>\n"
 "Language-Team: \n"
@@ -126,8 +130,8 @@ msgstr "Couleur copiée"
 #: src/lib/preferences/general/feedbackSettings.ts:259
 #: src/lib/preferences/general/feedbackSettings.ts:308
 #: src/lib/preferences/shortcuts/itemShortcuts.ts:39
-#: src/lib/ui/components/editDialog.ts:217
-#: src/lib/ui/components/editDialog.ts:244
+#: src/lib/ui/components/editDialog.ts:225
+#: src/lib/ui/components/editDialog.ts:252
 msgid "None"
 msgstr "Aucun"
 
@@ -156,7 +160,7 @@ msgstr "Code"
 #: src/lib/preferences/actions/actionDialog.ts:177
 #: src/lib/preferences/actions/actionDialog.ts:370
 #: src/lib/preferences/customization/items/fileItemCustomization.ts:79
-#: src/lib/ui/items/imageItem.ts:38
+#: src/lib/ui/items/imageItem.ts:37
 msgid "Image"
 msgstr "Image"
 
@@ -170,7 +174,7 @@ msgstr "Fichier"
 #: src/lib/preferences/actions/actionDefaults.ts:148
 #: src/lib/preferences/actions/actionDialog.ts:179
 #: src/lib/preferences/actions/actionDialog.ts:376
-#: src/lib/ui/items/filesItem.ts:140
+#: src/lib/ui/items/filesItem.ts:139
 msgid "Files"
 msgstr "Fichiers"
 
@@ -178,7 +182,7 @@ msgstr "Fichiers"
 #: src/lib/preferences/actions/actionDialog.ts:180
 #: src/lib/preferences/actions/actionDialog.ts:379
 #: src/lib/preferences/customization/items/linkItemCustomization.ts:45
-#: src/lib/ui/items/linkItem.ts:303
+#: src/lib/ui/items/linkItem.ts:304
 msgid "Link"
 msgstr "Lien"
 
@@ -217,7 +221,7 @@ msgstr "Sélectionnez les types autorisés"
 #: src/lib/preferences/dependencies/dependencies.ts:224
 #: src/lib/preferences/general/appExclusionSettings.ts:171
 #: src/lib/preferences/shortcuts/shortcutRow.ts:131
-#: src/lib/ui/components/editDialog.ts:306 src/lib/ui/indicator.ts:47
+#: src/lib/ui/components/editDialog.ts:314 src/lib/ui/indicator.ts:47
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -348,7 +352,7 @@ msgid "Edit Action"
 msgstr "Modifier l'action"
 
 #: src/lib/preferences/actions/actionDialog.ts:662
-#: src/lib/ui/components/editDialog.ts:313
+#: src/lib/ui/components/editDialog.ts:321
 msgid "Save"
 msgstr "Enregistrer"
 
@@ -1513,7 +1517,7 @@ msgstr ""
 "vous redémarrez, vous déconnectez ou éteignez votre système"
 
 #: src/lib/preferences/general/historySettings.ts:137
-#: src/lib/ui/clipboardDialog.ts:130 src/lib/ui/clipboardDialog.ts:235
+#: src/lib/ui/clipboardDialog.ts:134 src/lib/ui/clipboardDialog.ts:239
 #: src/lib/ui/indicator.ts:54
 msgid "Clear"
 msgstr "Effacer"
@@ -1521,6 +1525,10 @@ msgstr "Effacer"
 #: src/lib/preferences/general/historySettings.ts:137
 msgid "Keep All"
 msgstr "Tout conserver"
+
+#: src/lib/preferences/general/historySettings.ts:137
+msgid "Keep Pinned"
+msgstr ""
 
 #: src/lib/preferences/general/historySettings.ts:137
 msgid "Keep Pinned/Tagged"
@@ -1781,7 +1789,7 @@ msgstr "Fichier manquant"
 msgid "Error"
 msgstr "Erreur"
 
-#: src/lib/ui/components/editDialog.ts:269
+#: src/lib/ui/components/editDialog.ts:277
 msgid "Edit Clipboard Item"
 msgstr "Modifier l'élément du presse-papiers"
 
@@ -1798,22 +1806,22 @@ msgid "Are you sure you want to clear your clipboard history?"
 msgstr "Êtes-vous sûr de vouloir effacer votre historique du presse-papiers ?"
 
 #: src/lib/ui/indicator.ts:43
-msgid "Clear Pinned/Tagged Items"
-msgstr "Effacer les éléments épinglés/marqués"
+msgid "Clear Pinned Items"
+msgstr ""
 
-#: src/lib/ui/indicator.ts:102
+#: src/lib/ui/indicator.ts:99
 msgid "Incognito Mode"
 msgstr "Mode Incognito"
 
-#: src/lib/ui/indicator.ts:105
+#: src/lib/ui/indicator.ts:102
 msgid "Clear History"
 msgstr "Effacer l'historique"
 
-#: src/lib/ui/indicator.ts:106
+#: src/lib/ui/indicator.ts:103
 msgid "Settings"
 msgstr "Paramètres"
 
-#: src/lib/ui/indicator.ts:199
+#: src/lib/ui/indicator.ts:196
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -1824,14 +1832,14 @@ msgstr[1] "%d Fichiers"
 msgid "Char"
 msgstr "Car"
 
-#: src/lib/ui/items/filesItem.ts:120
+#: src/lib/ui/items/filesItem.ts:119
 #, javascript-format
 msgid "%d more file"
 msgid_plural "%d more files"
 msgstr[0] "%d fichier supplémentaire"
 msgstr[1] "%d fichiers supplémentaires"
 
-#: src/lib/ui/items/filesItem.ts:121
+#: src/lib/ui/items/filesItem.ts:120
 #, javascript-format
 msgid "%d file"
 msgid_plural "%d files"
@@ -1854,6 +1862,7 @@ msgstr "Le presse-papiers est vide"
 msgid "No Items Found"
 msgstr "Aucun élément trouvé"
 
+<<<<<<< Updated upstream
 #: src/lib/ui/searchEntry.ts:150
 msgid "__All"
 msgstr "__Tout"
@@ -1891,6 +1900,45 @@ msgid "Colo__r"
 msgstr "Couleu__r"
 
 #: src/lib/ui/searchEntry.ts:273
+=======
+#: src/lib/ui/searchEntry.ts:154
+msgid "__All"
+msgstr "__Tout"
+
+#: src/lib/ui/searchEntry.ts:158
+msgid "__Text"
+msgstr "__Texte"
+
+#: src/lib/ui/searchEntry.ts:159
+msgid "__Code"
+msgstr "__Code"
+
+#: src/lib/ui/searchEntry.ts:160
+msgid "__Image"
+msgstr "__Image"
+
+#: src/lib/ui/searchEntry.ts:161
+msgid "__File"
+msgstr "__Fichier"
+
+#: src/lib/ui/searchEntry.ts:162
+msgid "File__s"
+msgstr "Fichier__s"
+
+#: src/lib/ui/searchEntry.ts:163
+msgid "__Link"
+msgstr "__Lien"
+
+#: src/lib/ui/searchEntry.ts:164
+msgid "C__haracter"
+msgstr "C__aractère"
+
+#: src/lib/ui/searchEntry.ts:165
+msgid "Colo__r"
+msgstr "Couleu__r"
+
+#: src/lib/ui/searchEntry.ts:277
+>>>>>>> Stashed changes
 msgid "Type to search"
 msgstr "Tapez pour rechercher"
 

--- a/resources/po/fr.po
+++ b/resources/po/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-09 00:47-0300\n"
+"POT-Creation-Date: 2026-08-16 16:01-0300\n"
 "PO-Revision-Date: 2025-12-06 04:59+0100\n"
 "Last-Translator: Axel Haustant <noirbizarre@gmail.com>\n"
 "Language-Team: \n"
@@ -85,39 +85,39 @@ msgstr "Désactiver l'avertissement"
 msgid "Failed to load JSON"
 msgstr ""
 
-#: src/lib/misc/notifications.ts:63 src/lib/misc/notifications.ts:114
+#: src/lib/misc/notifications.ts:63 src/lib/misc/notifications.ts:125
 msgid "Copied Text"
 msgstr "Texte copié"
 
-#: src/lib/misc/notifications.ts:98 src/lib/misc/notifications.ts:123
+#: src/lib/misc/notifications.ts:109 src/lib/misc/notifications.ts:134
 msgid "Copied Image"
 msgstr "Image copiée"
 
-#: src/lib/misc/notifications.ts:99 src/lib/misc/notifications.ts:129
+#: src/lib/misc/notifications.ts:110 src/lib/misc/notifications.ts:140
 #, javascript-format
 msgid "Size: %d×%d px"
 msgstr "Taille : %d×%d px"
 
-#: src/lib/misc/notifications.ts:118
+#: src/lib/misc/notifications.ts:129
 msgid "Copied Code"
 msgstr "Code copié"
 
-#: src/lib/misc/notifications.ts:142
+#: src/lib/misc/notifications.ts:153
 #, javascript-format
 msgid "Copied %d File"
 msgid_plural "Copied %d Files"
 msgstr[0] "Copié %d fichier"
 msgstr[1] "Copié %d fichiers"
 
-#: src/lib/misc/notifications.ts:148
+#: src/lib/misc/notifications.ts:159
 msgid "Copied Link"
 msgstr "Lien copié"
 
-#: src/lib/misc/notifications.ts:152
+#: src/lib/misc/notifications.ts:163
 msgid "Copied Character"
 msgstr "Caractère copié"
 
-#: src/lib/misc/notifications.ts:156
+#: src/lib/misc/notifications.ts:167
 msgid "Copied Color"
 msgstr "Couleur copiée"
 
@@ -1741,47 +1741,47 @@ msgstr "Désactiver le raccourci"
 msgid "Disabled"
 msgstr "Désactivé"
 
-#: src/lib/ui/components/contentInfo.ts:32
+#: src/lib/ui/components/contentInfo.ts:35
 #, javascript-format
 msgid "%dh"
 msgstr "%dh"
 
-#: src/lib/ui/components/contentInfo.ts:33
+#: src/lib/ui/components/contentInfo.ts:36
 #, javascript-format
 msgid "%dm"
 msgstr "%dm"
 
-#: src/lib/ui/components/contentInfo.ts:34
+#: src/lib/ui/components/contentInfo.ts:37
 #, javascript-format
 msgid "%ds"
 msgstr "%ds"
 
-#: src/lib/ui/components/contentInfo.ts:106
+#: src/lib/ui/components/contentInfo.ts:116
 #, javascript-format
 msgid "%d char"
 msgid_plural "%d chars"
 msgstr[0] "%d caractère"
 msgstr[1] "%d caractères"
 
-#: src/lib/ui/components/contentInfo.ts:114
+#: src/lib/ui/components/contentInfo.ts:123
 #, javascript-format
 msgid "%d word"
 msgid_plural "%d words"
 msgstr[0] "%d mot"
 msgstr[1] "%d mots"
 
-#: src/lib/ui/components/contentInfo.ts:117
+#: src/lib/ui/components/contentInfo.ts:126
 #, javascript-format
 msgid "%d line"
 msgid_plural "%d lines"
 msgstr[0] "%d ligne"
 msgstr[1] "%d lignes"
 
-#: src/lib/ui/components/contentInfo.ts:177
+#: src/lib/ui/components/contentInfo.ts:186
 msgid "Missing File"
 msgstr "Fichier manquant"
 
-#: src/lib/ui/components/contentInfo.ts:189
+#: src/lib/ui/components/contentInfo.ts:198
 msgid "Error"
 msgstr "Erreur"
 

--- a/resources/po/it.po
+++ b/resources/po/it.po
@@ -6,11 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-<<<<<<< Updated upstream
-"POT-Creation-Date: 2026-04-26 12:23-0500\n"
-=======
-"POT-Creation-Date: 2026-07-09 00:11-0300\n"
->>>>>>> Stashed changes
+"POT-Creation-Date: 2026-07-09 00:47-0300\n"
 "PO-Revision-Date: 2025-12-14 10:45+0100\n"
 "Last-Translator: Fabian Esposito <fabian.esposito@outlook.com>\n"
 "Language-Team: Italiano\n"
@@ -219,7 +215,7 @@ msgstr "Seleziona quali tipi sono consentiti"
 #: src/lib/preferences/dependencies/dependencies.ts:224
 #: src/lib/preferences/general/appExclusionSettings.ts:171
 #: src/lib/preferences/shortcuts/shortcutRow.ts:131
-#: src/lib/ui/components/editDialog.ts:314 src/lib/ui/indicator.ts:47
+#: src/lib/ui/components/editDialog.ts:315 src/lib/ui/indicator.ts:47
 msgid "Cancel"
 msgstr "Annulla"
 
@@ -350,7 +346,7 @@ msgid "Edit Action"
 msgstr "Modifica l'azione"
 
 #: src/lib/preferences/actions/actionDialog.ts:662
-#: src/lib/ui/components/editDialog.ts:321
+#: src/lib/ui/components/editDialog.ts:322
 msgid "Save"
 msgstr "Salva"
 
@@ -1852,45 +1848,6 @@ msgstr "Gli appunti sono vuoti"
 msgid "No Items Found"
 msgstr "Nessun elemento trovato"
 
-<<<<<<< Updated upstream
-#: src/lib/ui/searchEntry.ts:150
-msgid "__All"
-msgstr "__Tutto"
-
-#: src/lib/ui/searchEntry.ts:154
-msgid "__Text"
-msgstr "__Testo"
-
-#: src/lib/ui/searchEntry.ts:155
-msgid "__Code"
-msgstr "__Codice"
-
-#: src/lib/ui/searchEntry.ts:156
-msgid "__Image"
-msgstr "__Immagine"
-
-#: src/lib/ui/searchEntry.ts:157
-msgid "__File"
-msgstr "__File"
-
-#: src/lib/ui/searchEntry.ts:158
-msgid "File__s"
-msgstr "File__s"
-
-#: src/lib/ui/searchEntry.ts:159
-msgid "__Link"
-msgstr "__Link"
-
-#: src/lib/ui/searchEntry.ts:160
-msgid "C__haracter"
-msgstr "C__arattere"
-
-#: src/lib/ui/searchEntry.ts:161
-msgid "Colo__r"
-msgstr "Color__e"
-
-#: src/lib/ui/searchEntry.ts:273
-=======
 #: src/lib/ui/searchEntry.ts:154
 msgid "__All"
 msgstr "__Tutto"
@@ -1928,7 +1885,6 @@ msgid "Colo__r"
 msgstr "Color__e"
 
 #: src/lib/ui/searchEntry.ts:277
->>>>>>> Stashed changes
 msgid "Type to search"
 msgstr "Digitare per la ricerca"
 

--- a/resources/po/it.po
+++ b/resources/po/it.po
@@ -6,7 +6,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
+<<<<<<< Updated upstream
 "POT-Creation-Date: 2026-04-26 12:23-0500\n"
+=======
+"POT-Creation-Date: 2026-07-09 00:11-0300\n"
+>>>>>>> Stashed changes
 "PO-Revision-Date: 2025-12-14 10:45+0100\n"
 "Last-Translator: Fabian Esposito <fabian.esposito@outlook.com>\n"
 "Language-Team: Italiano\n"
@@ -124,8 +128,8 @@ msgstr "Colore copiato"
 #: src/lib/preferences/general/feedbackSettings.ts:259
 #: src/lib/preferences/general/feedbackSettings.ts:308
 #: src/lib/preferences/shortcuts/itemShortcuts.ts:39
-#: src/lib/ui/components/editDialog.ts:217
-#: src/lib/ui/components/editDialog.ts:244
+#: src/lib/ui/components/editDialog.ts:225
+#: src/lib/ui/components/editDialog.ts:252
 msgid "None"
 msgstr "Nessuno"
 
@@ -154,7 +158,7 @@ msgstr "Codice"
 #: src/lib/preferences/actions/actionDialog.ts:177
 #: src/lib/preferences/actions/actionDialog.ts:370
 #: src/lib/preferences/customization/items/fileItemCustomization.ts:79
-#: src/lib/ui/items/imageItem.ts:38
+#: src/lib/ui/items/imageItem.ts:37
 msgid "Image"
 msgstr "Immagine"
 
@@ -168,7 +172,7 @@ msgstr "File"
 #: src/lib/preferences/actions/actionDefaults.ts:148
 #: src/lib/preferences/actions/actionDialog.ts:179
 #: src/lib/preferences/actions/actionDialog.ts:376
-#: src/lib/ui/items/filesItem.ts:140
+#: src/lib/ui/items/filesItem.ts:139
 msgid "Files"
 msgstr "File"
 
@@ -176,7 +180,7 @@ msgstr "File"
 #: src/lib/preferences/actions/actionDialog.ts:180
 #: src/lib/preferences/actions/actionDialog.ts:379
 #: src/lib/preferences/customization/items/linkItemCustomization.ts:45
-#: src/lib/ui/items/linkItem.ts:303
+#: src/lib/ui/items/linkItem.ts:304
 msgid "Link"
 msgstr "Link"
 
@@ -215,7 +219,7 @@ msgstr "Seleziona quali tipi sono consentiti"
 #: src/lib/preferences/dependencies/dependencies.ts:224
 #: src/lib/preferences/general/appExclusionSettings.ts:171
 #: src/lib/preferences/shortcuts/shortcutRow.ts:131
-#: src/lib/ui/components/editDialog.ts:306 src/lib/ui/indicator.ts:47
+#: src/lib/ui/components/editDialog.ts:314 src/lib/ui/indicator.ts:47
 msgid "Cancel"
 msgstr "Annulla"
 
@@ -346,7 +350,7 @@ msgid "Edit Action"
 msgstr "Modifica l'azione"
 
 #: src/lib/preferences/actions/actionDialog.ts:662
-#: src/lib/ui/components/editDialog.ts:313
+#: src/lib/ui/components/editDialog.ts:321
 msgid "Save"
 msgstr "Salva"
 
@@ -1504,7 +1508,7 @@ msgstr ""
 "disconnessione o spegnimento del sistema"
 
 #: src/lib/preferences/general/historySettings.ts:137
-#: src/lib/ui/clipboardDialog.ts:130 src/lib/ui/clipboardDialog.ts:235
+#: src/lib/ui/clipboardDialog.ts:134 src/lib/ui/clipboardDialog.ts:239
 #: src/lib/ui/indicator.ts:54
 msgid "Clear"
 msgstr "Cancella"
@@ -1512,6 +1516,10 @@ msgstr "Cancella"
 #: src/lib/preferences/general/historySettings.ts:137
 msgid "Keep All"
 msgstr "Conserva tutto"
+
+#: src/lib/preferences/general/historySettings.ts:137
+msgid "Keep Pinned"
+msgstr ""
 
 #: src/lib/preferences/general/historySettings.ts:137
 msgid "Keep Pinned/Tagged"
@@ -1771,7 +1779,7 @@ msgstr "File mancante"
 msgid "Error"
 msgstr "Errore"
 
-#: src/lib/ui/components/editDialog.ts:269
+#: src/lib/ui/components/editDialog.ts:277
 msgid "Edit Clipboard Item"
 msgstr "Modifica elemento degli appunti"
 
@@ -1788,22 +1796,22 @@ msgid "Are you sure you want to clear your clipboard history?"
 msgstr "Sei sicuro di voler cancellare la cronologia dei tuoi appunti?"
 
 #: src/lib/ui/indicator.ts:43
-msgid "Clear Pinned/Tagged Items"
-msgstr "Cancella elementi fissati/contrassegnati"
+msgid "Clear Pinned Items"
+msgstr ""
 
-#: src/lib/ui/indicator.ts:102
+#: src/lib/ui/indicator.ts:99
 msgid "Incognito Mode"
 msgstr "Modalità Incognito"
 
-#: src/lib/ui/indicator.ts:105
+#: src/lib/ui/indicator.ts:102
 msgid "Clear History"
 msgstr "Cancella la cronologia"
 
-#: src/lib/ui/indicator.ts:106
+#: src/lib/ui/indicator.ts:103
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: src/lib/ui/indicator.ts:199
+#: src/lib/ui/indicator.ts:196
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -1814,14 +1822,14 @@ msgstr[1] "%d file"
 msgid "Char"
 msgstr "Car"
 
-#: src/lib/ui/items/filesItem.ts:120
+#: src/lib/ui/items/filesItem.ts:119
 #, javascript-format
 msgid "%d more file"
 msgid_plural "%d more files"
 msgstr[0] "%d altro file"
 msgstr[1] "%d altri file"
 
-#: src/lib/ui/items/filesItem.ts:121
+#: src/lib/ui/items/filesItem.ts:120
 #, javascript-format
 msgid "%d file"
 msgid_plural "%d files"
@@ -1844,6 +1852,7 @@ msgstr "Gli appunti sono vuoti"
 msgid "No Items Found"
 msgstr "Nessun elemento trovato"
 
+<<<<<<< Updated upstream
 #: src/lib/ui/searchEntry.ts:150
 msgid "__All"
 msgstr "__Tutto"
@@ -1881,6 +1890,45 @@ msgid "Colo__r"
 msgstr "Color__e"
 
 #: src/lib/ui/searchEntry.ts:273
+=======
+#: src/lib/ui/searchEntry.ts:154
+msgid "__All"
+msgstr "__Tutto"
+
+#: src/lib/ui/searchEntry.ts:158
+msgid "__Text"
+msgstr "__Testo"
+
+#: src/lib/ui/searchEntry.ts:159
+msgid "__Code"
+msgstr "__Codice"
+
+#: src/lib/ui/searchEntry.ts:160
+msgid "__Image"
+msgstr "__Immagine"
+
+#: src/lib/ui/searchEntry.ts:161
+msgid "__File"
+msgstr "__File"
+
+#: src/lib/ui/searchEntry.ts:162
+msgid "File__s"
+msgstr "File__s"
+
+#: src/lib/ui/searchEntry.ts:163
+msgid "__Link"
+msgstr "__Link"
+
+#: src/lib/ui/searchEntry.ts:164
+msgid "C__haracter"
+msgstr "C__arattere"
+
+#: src/lib/ui/searchEntry.ts:165
+msgid "Colo__r"
+msgstr "Color__e"
+
+#: src/lib/ui/searchEntry.ts:277
+>>>>>>> Stashed changes
 msgid "Type to search"
 msgstr "Digitare per la ricerca"
 

--- a/resources/po/it.po
+++ b/resources/po/it.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-09 00:47-0300\n"
+"POT-Creation-Date: 2026-08-16 16:01-0300\n"
 "PO-Revision-Date: 2025-12-14 10:45+0100\n"
 "Last-Translator: Fabian Esposito <fabian.esposito@outlook.com>\n"
 "Language-Team: Italiano\n"
@@ -83,39 +83,39 @@ msgstr "Disabilita avviso"
 msgid "Failed to load JSON"
 msgstr ""
 
-#: src/lib/misc/notifications.ts:63 src/lib/misc/notifications.ts:114
+#: src/lib/misc/notifications.ts:63 src/lib/misc/notifications.ts:125
 msgid "Copied Text"
 msgstr "Testo copiato"
 
-#: src/lib/misc/notifications.ts:98 src/lib/misc/notifications.ts:123
+#: src/lib/misc/notifications.ts:109 src/lib/misc/notifications.ts:134
 msgid "Copied Image"
 msgstr "Immagine copiata"
 
-#: src/lib/misc/notifications.ts:99 src/lib/misc/notifications.ts:129
+#: src/lib/misc/notifications.ts:110 src/lib/misc/notifications.ts:140
 #, javascript-format
 msgid "Size: %d×%d px"
 msgstr "Dimensione: %d×%d px"
 
-#: src/lib/misc/notifications.ts:118
+#: src/lib/misc/notifications.ts:129
 msgid "Copied Code"
 msgstr "Codice copiato"
 
-#: src/lib/misc/notifications.ts:142
+#: src/lib/misc/notifications.ts:153
 #, javascript-format
 msgid "Copied %d File"
 msgid_plural "Copied %d Files"
 msgstr[0] "Copiato %d file"
 msgstr[1] "Copiati %d file"
 
-#: src/lib/misc/notifications.ts:148
+#: src/lib/misc/notifications.ts:159
 msgid "Copied Link"
 msgstr "Link copiato"
 
-#: src/lib/misc/notifications.ts:152
+#: src/lib/misc/notifications.ts:163
 msgid "Copied Character"
 msgstr "Carattere copiato"
 
-#: src/lib/misc/notifications.ts:156
+#: src/lib/misc/notifications.ts:167
 msgid "Copied Color"
 msgstr "Colore copiato"
 
@@ -1731,47 +1731,47 @@ msgstr "Disabilita scorciatoia"
 msgid "Disabled"
 msgstr "Disabilitato"
 
-#: src/lib/ui/components/contentInfo.ts:32
+#: src/lib/ui/components/contentInfo.ts:35
 #, javascript-format
 msgid "%dh"
 msgstr "%dh"
 
-#: src/lib/ui/components/contentInfo.ts:33
+#: src/lib/ui/components/contentInfo.ts:36
 #, javascript-format
 msgid "%dm"
 msgstr "%dm"
 
-#: src/lib/ui/components/contentInfo.ts:34
+#: src/lib/ui/components/contentInfo.ts:37
 #, javascript-format
 msgid "%ds"
 msgstr "%ds"
 
-#: src/lib/ui/components/contentInfo.ts:106
+#: src/lib/ui/components/contentInfo.ts:116
 #, javascript-format
 msgid "%d char"
 msgid_plural "%d chars"
 msgstr[0] "%d carattere"
 msgstr[1] "%d caratteri"
 
-#: src/lib/ui/components/contentInfo.ts:114
+#: src/lib/ui/components/contentInfo.ts:123
 #, javascript-format
 msgid "%d word"
 msgid_plural "%d words"
 msgstr[0] "%d parola"
 msgstr[1] "%d parole"
 
-#: src/lib/ui/components/contentInfo.ts:117
+#: src/lib/ui/components/contentInfo.ts:126
 #, javascript-format
 msgid "%d line"
 msgid_plural "%d lines"
 msgstr[0] "%d riga"
 msgstr[1] "%d righe"
 
-#: src/lib/ui/components/contentInfo.ts:177
+#: src/lib/ui/components/contentInfo.ts:186
 msgid "Missing File"
 msgstr "File mancante"
 
-#: src/lib/ui/components/contentInfo.ts:189
+#: src/lib/ui/components/contentInfo.ts:198
 msgid "Error"
 msgstr "Errore"
 

--- a/resources/po/main.pot
+++ b/resources/po/main.pot
@@ -8,11 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-<<<<<<< Updated upstream
-"POT-Creation-Date: 2026-04-26 12:23-0500\n"
-=======
-"POT-Creation-Date: 2026-07-09 00:11-0300\n"
->>>>>>> Stashed changes
+"POT-Creation-Date: 2026-07-09 00:47-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -220,7 +216,7 @@ msgstr ""
 #: src/lib/preferences/dependencies/dependencies.ts:224
 #: src/lib/preferences/general/appExclusionSettings.ts:171
 #: src/lib/preferences/shortcuts/shortcutRow.ts:131
-#: src/lib/ui/components/editDialog.ts:314 src/lib/ui/indicator.ts:47
+#: src/lib/ui/components/editDialog.ts:315 src/lib/ui/indicator.ts:47
 msgid "Cancel"
 msgstr ""
 
@@ -346,7 +342,7 @@ msgid "Edit Action"
 msgstr ""
 
 #: src/lib/preferences/actions/actionDialog.ts:662
-#: src/lib/ui/components/editDialog.ts:321
+#: src/lib/ui/components/editDialog.ts:322
 msgid "Save"
 msgstr ""
 
@@ -1798,43 +1794,43 @@ msgstr ""
 msgid "No Items Found"
 msgstr ""
 
-#: src/lib/ui/searchEntry.ts:150
+#: src/lib/ui/searchEntry.ts:154
 msgid "__All"
 msgstr ""
 
-#: src/lib/ui/searchEntry.ts:154
+#: src/lib/ui/searchEntry.ts:158
 msgid "__Text"
 msgstr ""
 
-#: src/lib/ui/searchEntry.ts:155
+#: src/lib/ui/searchEntry.ts:159
 msgid "__Code"
 msgstr ""
 
-#: src/lib/ui/searchEntry.ts:156
+#: src/lib/ui/searchEntry.ts:160
 msgid "__Image"
 msgstr ""
 
-#: src/lib/ui/searchEntry.ts:157
+#: src/lib/ui/searchEntry.ts:161
 msgid "__File"
 msgstr ""
 
-#: src/lib/ui/searchEntry.ts:158
+#: src/lib/ui/searchEntry.ts:162
 msgid "File__s"
 msgstr ""
 
-#: src/lib/ui/searchEntry.ts:159
+#: src/lib/ui/searchEntry.ts:163
 msgid "__Link"
 msgstr ""
 
-#: src/lib/ui/searchEntry.ts:160
+#: src/lib/ui/searchEntry.ts:164
 msgid "C__haracter"
 msgstr ""
 
-#: src/lib/ui/searchEntry.ts:161
+#: src/lib/ui/searchEntry.ts:165
 msgid "Colo__r"
 msgstr ""
 
-#: src/lib/ui/searchEntry.ts:273
+#: src/lib/ui/searchEntry.ts:277
 msgid "Type to search"
 msgstr ""
 

--- a/resources/po/main.pot
+++ b/resources/po/main.pot
@@ -8,7 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
+<<<<<<< Updated upstream
 "POT-Creation-Date: 2026-04-26 12:23-0500\n"
+=======
+"POT-Creation-Date: 2026-07-09 00:11-0300\n"
+>>>>>>> Stashed changes
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -125,8 +129,8 @@ msgstr ""
 #: src/lib/preferences/general/feedbackSettings.ts:259
 #: src/lib/preferences/general/feedbackSettings.ts:308
 #: src/lib/preferences/shortcuts/itemShortcuts.ts:39
-#: src/lib/ui/components/editDialog.ts:217
-#: src/lib/ui/components/editDialog.ts:244
+#: src/lib/ui/components/editDialog.ts:225
+#: src/lib/ui/components/editDialog.ts:252
 msgid "None"
 msgstr ""
 
@@ -155,7 +159,7 @@ msgstr ""
 #: src/lib/preferences/actions/actionDialog.ts:177
 #: src/lib/preferences/actions/actionDialog.ts:370
 #: src/lib/preferences/customization/items/fileItemCustomization.ts:79
-#: src/lib/ui/items/imageItem.ts:38
+#: src/lib/ui/items/imageItem.ts:37
 msgid "Image"
 msgstr ""
 
@@ -169,7 +173,7 @@ msgstr ""
 #: src/lib/preferences/actions/actionDefaults.ts:148
 #: src/lib/preferences/actions/actionDialog.ts:179
 #: src/lib/preferences/actions/actionDialog.ts:376
-#: src/lib/ui/items/filesItem.ts:140
+#: src/lib/ui/items/filesItem.ts:139
 msgid "Files"
 msgstr ""
 
@@ -177,7 +181,7 @@ msgstr ""
 #: src/lib/preferences/actions/actionDialog.ts:180
 #: src/lib/preferences/actions/actionDialog.ts:379
 #: src/lib/preferences/customization/items/linkItemCustomization.ts:45
-#: src/lib/ui/items/linkItem.ts:303
+#: src/lib/ui/items/linkItem.ts:304
 msgid "Link"
 msgstr ""
 
@@ -216,7 +220,7 @@ msgstr ""
 #: src/lib/preferences/dependencies/dependencies.ts:224
 #: src/lib/preferences/general/appExclusionSettings.ts:171
 #: src/lib/preferences/shortcuts/shortcutRow.ts:131
-#: src/lib/ui/components/editDialog.ts:306 src/lib/ui/indicator.ts:47
+#: src/lib/ui/components/editDialog.ts:314 src/lib/ui/indicator.ts:47
 msgid "Cancel"
 msgstr ""
 
@@ -342,7 +346,7 @@ msgid "Edit Action"
 msgstr ""
 
 #: src/lib/preferences/actions/actionDialog.ts:662
-#: src/lib/ui/components/editDialog.ts:313
+#: src/lib/ui/components/editDialog.ts:321
 msgid "Save"
 msgstr ""
 
@@ -1456,13 +1460,17 @@ msgid ""
 msgstr ""
 
 #: src/lib/preferences/general/historySettings.ts:137
-#: src/lib/ui/clipboardDialog.ts:130 src/lib/ui/clipboardDialog.ts:235
+#: src/lib/ui/clipboardDialog.ts:134 src/lib/ui/clipboardDialog.ts:239
 #: src/lib/ui/indicator.ts:54
 msgid "Clear"
 msgstr ""
 
 #: src/lib/preferences/general/historySettings.ts:137
 msgid "Keep All"
+msgstr ""
+
+#: src/lib/preferences/general/historySettings.ts:137
+msgid "Keep Pinned"
 msgstr ""
 
 #: src/lib/preferences/general/historySettings.ts:137
@@ -1717,7 +1725,7 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: src/lib/ui/components/editDialog.ts:269
+#: src/lib/ui/components/editDialog.ts:277
 msgid "Edit Clipboard Item"
 msgstr ""
 
@@ -1734,22 +1742,22 @@ msgid "Are you sure you want to clear your clipboard history?"
 msgstr ""
 
 #: src/lib/ui/indicator.ts:43
-msgid "Clear Pinned/Tagged Items"
+msgid "Clear Pinned Items"
 msgstr ""
 
-#: src/lib/ui/indicator.ts:102
+#: src/lib/ui/indicator.ts:99
 msgid "Incognito Mode"
 msgstr ""
 
-#: src/lib/ui/indicator.ts:105
+#: src/lib/ui/indicator.ts:102
 msgid "Clear History"
 msgstr ""
 
-#: src/lib/ui/indicator.ts:106
+#: src/lib/ui/indicator.ts:103
 msgid "Settings"
 msgstr ""
 
-#: src/lib/ui/indicator.ts:199
+#: src/lib/ui/indicator.ts:196
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -1760,14 +1768,14 @@ msgstr[1] ""
 msgid "Char"
 msgstr ""
 
-#: src/lib/ui/items/filesItem.ts:120
+#: src/lib/ui/items/filesItem.ts:119
 #, javascript-format
 msgid "%d more file"
 msgid_plural "%d more files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/lib/ui/items/filesItem.ts:121
+#: src/lib/ui/items/filesItem.ts:120
 #, javascript-format
 msgid "%d file"
 msgid_plural "%d files"

--- a/resources/po/main.pot
+++ b/resources/po/main.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-09 00:47-0300\n"
+"POT-Creation-Date: 2026-08-16 16:01-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -84,39 +84,39 @@ msgstr ""
 msgid "Failed to load JSON"
 msgstr ""
 
-#: src/lib/misc/notifications.ts:63 src/lib/misc/notifications.ts:114
+#: src/lib/misc/notifications.ts:63 src/lib/misc/notifications.ts:125
 msgid "Copied Text"
 msgstr ""
 
-#: src/lib/misc/notifications.ts:98 src/lib/misc/notifications.ts:123
+#: src/lib/misc/notifications.ts:109 src/lib/misc/notifications.ts:134
 msgid "Copied Image"
 msgstr ""
 
-#: src/lib/misc/notifications.ts:99 src/lib/misc/notifications.ts:129
+#: src/lib/misc/notifications.ts:110 src/lib/misc/notifications.ts:140
 #, javascript-format
 msgid "Size: %d×%d px"
 msgstr ""
 
-#: src/lib/misc/notifications.ts:118
+#: src/lib/misc/notifications.ts:129
 msgid "Copied Code"
 msgstr ""
 
-#: src/lib/misc/notifications.ts:142
+#: src/lib/misc/notifications.ts:153
 #, javascript-format
 msgid "Copied %d File"
 msgid_plural "Copied %d Files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/lib/misc/notifications.ts:148
+#: src/lib/misc/notifications.ts:159
 msgid "Copied Link"
 msgstr ""
 
-#: src/lib/misc/notifications.ts:152
+#: src/lib/misc/notifications.ts:163
 msgid "Copied Character"
 msgstr ""
 
-#: src/lib/misc/notifications.ts:156
+#: src/lib/misc/notifications.ts:167
 msgid "Copied Color"
 msgstr ""
 
@@ -1677,47 +1677,47 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: src/lib/ui/components/contentInfo.ts:32
+#: src/lib/ui/components/contentInfo.ts:35
 #, javascript-format
 msgid "%dh"
 msgstr ""
 
-#: src/lib/ui/components/contentInfo.ts:33
+#: src/lib/ui/components/contentInfo.ts:36
 #, javascript-format
 msgid "%dm"
 msgstr ""
 
-#: src/lib/ui/components/contentInfo.ts:34
+#: src/lib/ui/components/contentInfo.ts:37
 #, javascript-format
 msgid "%ds"
 msgstr ""
 
-#: src/lib/ui/components/contentInfo.ts:106
+#: src/lib/ui/components/contentInfo.ts:116
 #, javascript-format
 msgid "%d char"
 msgid_plural "%d chars"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/lib/ui/components/contentInfo.ts:114
+#: src/lib/ui/components/contentInfo.ts:123
 #, javascript-format
 msgid "%d word"
 msgid_plural "%d words"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/lib/ui/components/contentInfo.ts:117
+#: src/lib/ui/components/contentInfo.ts:126
 #, javascript-format
 msgid "%d line"
 msgid_plural "%d lines"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/lib/ui/components/contentInfo.ts:177
+#: src/lib/ui/components/contentInfo.ts:186
 msgid "Missing File"
 msgstr ""
 
-#: src/lib/ui/components/contentInfo.ts:189
+#: src/lib/ui/components/contentInfo.ts:198
 msgid "Error"
 msgstr ""
 

--- a/resources/po/pl.po
+++ b/resources/po/pl.po
@@ -8,8 +8,13 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
+<<<<<<< Updated upstream
 "POT-Creation-Date: 2026-04-26 12:23-0500\n"
 "PO-Revision-Date: 2026-04-17 08:33+0200\n"
+=======
+"POT-Creation-Date: 2026-07-09 00:11-0300\n"
+"PO-Revision-Date: 2026-04-30 18:05+0200\n"
+>>>>>>> Stashed changes
 "Last-Translator: Adam Lewicki <a.lewicki95@gmail.com>\n"
 "Language-Team: \n"
 "Language: pl\n"
@@ -128,8 +133,8 @@ msgstr "Skopiowany kolor"
 #: src/lib/preferences/general/feedbackSettings.ts:259
 #: src/lib/preferences/general/feedbackSettings.ts:308
 #: src/lib/preferences/shortcuts/itemShortcuts.ts:39
-#: src/lib/ui/components/editDialog.ts:217
-#: src/lib/ui/components/editDialog.ts:244
+#: src/lib/ui/components/editDialog.ts:225
+#: src/lib/ui/components/editDialog.ts:252
 msgid "None"
 msgstr "Brak"
 
@@ -158,7 +163,7 @@ msgstr "Kod"
 #: src/lib/preferences/actions/actionDialog.ts:177
 #: src/lib/preferences/actions/actionDialog.ts:370
 #: src/lib/preferences/customization/items/fileItemCustomization.ts:79
-#: src/lib/ui/items/imageItem.ts:38
+#: src/lib/ui/items/imageItem.ts:37
 msgid "Image"
 msgstr "Obraz"
 
@@ -172,7 +177,7 @@ msgstr "Plik"
 #: src/lib/preferences/actions/actionDefaults.ts:148
 #: src/lib/preferences/actions/actionDialog.ts:179
 #: src/lib/preferences/actions/actionDialog.ts:376
-#: src/lib/ui/items/filesItem.ts:140
+#: src/lib/ui/items/filesItem.ts:139
 msgid "Files"
 msgstr "Pliki"
 
@@ -180,7 +185,7 @@ msgstr "Pliki"
 #: src/lib/preferences/actions/actionDialog.ts:180
 #: src/lib/preferences/actions/actionDialog.ts:379
 #: src/lib/preferences/customization/items/linkItemCustomization.ts:45
-#: src/lib/ui/items/linkItem.ts:303
+#: src/lib/ui/items/linkItem.ts:304
 msgid "Link"
 msgstr "Odnośnik"
 
@@ -219,7 +224,7 @@ msgstr "Wybierz dozwolone typy"
 #: src/lib/preferences/dependencies/dependencies.ts:224
 #: src/lib/preferences/general/appExclusionSettings.ts:171
 #: src/lib/preferences/shortcuts/shortcutRow.ts:131
-#: src/lib/ui/components/editDialog.ts:306 src/lib/ui/indicator.ts:47
+#: src/lib/ui/components/editDialog.ts:314 src/lib/ui/indicator.ts:47
 msgid "Cancel"
 msgstr "Anuluj"
 
@@ -350,7 +355,7 @@ msgid "Edit Action"
 msgstr "Edytuj akcję"
 
 #: src/lib/preferences/actions/actionDialog.ts:662
-#: src/lib/ui/components/editDialog.ts:313
+#: src/lib/ui/components/editDialog.ts:321
 msgid "Save"
 msgstr "Zapisz"
 
@@ -1498,7 +1503,7 @@ msgstr ""
 "wylogowywania lub zamykania systemu"
 
 #: src/lib/preferences/general/historySettings.ts:137
-#: src/lib/ui/clipboardDialog.ts:130 src/lib/ui/clipboardDialog.ts:235
+#: src/lib/ui/clipboardDialog.ts:134 src/lib/ui/clipboardDialog.ts:239
 #: src/lib/ui/indicator.ts:54
 msgid "Clear"
 msgstr "Wyczyść"
@@ -1506,6 +1511,10 @@ msgstr "Wyczyść"
 #: src/lib/preferences/general/historySettings.ts:137
 msgid "Keep All"
 msgstr "Zachowaj wszystko"
+
+#: src/lib/preferences/general/historySettings.ts:137
+msgid "Keep Pinned"
+msgstr ""
 
 #: src/lib/preferences/general/historySettings.ts:137
 msgid "Keep Pinned/Tagged"
@@ -1765,7 +1774,7 @@ msgstr "Brakujący plik"
 msgid "Error"
 msgstr "Błąd"
 
-#: src/lib/ui/components/editDialog.ts:269
+#: src/lib/ui/components/editDialog.ts:277
 msgid "Edit Clipboard Item"
 msgstr "Edytuj element schowka"
 
@@ -1782,22 +1791,22 @@ msgid "Are you sure you want to clear your clipboard history?"
 msgstr "Czy na pewno chcesz wyczyścić historię schowka?"
 
 #: src/lib/ui/indicator.ts:43
-msgid "Clear Pinned/Tagged Items"
-msgstr "Wyczyść przypięte/oznaczone elementy"
+msgid "Clear Pinned Items"
+msgstr ""
 
-#: src/lib/ui/indicator.ts:102
+#: src/lib/ui/indicator.ts:99
 msgid "Incognito Mode"
 msgstr "Tryb prywatny"
 
-#: src/lib/ui/indicator.ts:105
+#: src/lib/ui/indicator.ts:102
 msgid "Clear History"
 msgstr "Wyczyść historię"
 
-#: src/lib/ui/indicator.ts:106
+#: src/lib/ui/indicator.ts:103
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: src/lib/ui/indicator.ts:199
+#: src/lib/ui/indicator.ts:196
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -1809,7 +1818,7 @@ msgstr[2] "%d plików"
 msgid "Char"
 msgstr "Znak"
 
-#: src/lib/ui/items/filesItem.ts:120
+#: src/lib/ui/items/filesItem.ts:119
 #, javascript-format
 msgid "%d more file"
 msgid_plural "%d more files"
@@ -1817,7 +1826,7 @@ msgstr[0] "%d plik więcej"
 msgstr[1] "%d pliki więcej"
 msgstr[2] "%d plików więcej"
 
-#: src/lib/ui/items/filesItem.ts:121
+#: src/lib/ui/items/filesItem.ts:120
 #, javascript-format
 msgid "%d file"
 msgid_plural "%d files"
@@ -1841,6 +1850,7 @@ msgstr "Schowek jest pusty"
 msgid "No Items Found"
 msgstr "Nie znaleziono elementów"
 
+<<<<<<< Updated upstream
 #: src/lib/ui/searchEntry.ts:150
 msgid "__All"
 msgstr "__Wszystko"
@@ -1878,6 +1888,45 @@ msgid "Colo__r"
 msgstr "Kolo_r"
 
 #: src/lib/ui/searchEntry.ts:273
+=======
+#: src/lib/ui/searchEntry.ts:154
+msgid "__All"
+msgstr "__Wszystko"
+
+#: src/lib/ui/searchEntry.ts:158
+msgid "__Text"
+msgstr "__Tekst"
+
+#: src/lib/ui/searchEntry.ts:159
+msgid "__Code"
+msgstr "__Kod"
+
+#: src/lib/ui/searchEntry.ts:160
+msgid "__Image"
+msgstr "__Obraz"
+
+#: src/lib/ui/searchEntry.ts:161
+msgid "__File"
+msgstr "__Plik"
+
+#: src/lib/ui/searchEntry.ts:162
+msgid "File__s"
+msgstr "Plik_i"
+
+#: src/lib/ui/searchEntry.ts:163
+msgid "__Link"
+msgstr "__Odnośnik"
+
+#: src/lib/ui/searchEntry.ts:164
+msgid "C__haracter"
+msgstr "Z_nak"
+
+#: src/lib/ui/searchEntry.ts:165
+msgid "Colo__r"
+msgstr "Kolo_r"
+
+#: src/lib/ui/searchEntry.ts:277
+>>>>>>> Stashed changes
 msgid "Type to search"
 msgstr "Wpisz, aby wyszukać"
 

--- a/resources/po/pl.po
+++ b/resources/po/pl.po
@@ -8,13 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-<<<<<<< Updated upstream
-"POT-Creation-Date: 2026-04-26 12:23-0500\n"
-"PO-Revision-Date: 2026-04-17 08:33+0200\n"
-=======
-"POT-Creation-Date: 2026-07-09 00:11-0300\n"
+"POT-Creation-Date: 2026-07-09 00:47-0300\n"
 "PO-Revision-Date: 2026-04-30 18:05+0200\n"
->>>>>>> Stashed changes
 "Last-Translator: Adam Lewicki <a.lewicki95@gmail.com>\n"
 "Language-Team: \n"
 "Language: pl\n"
@@ -224,7 +219,7 @@ msgstr "Wybierz dozwolone typy"
 #: src/lib/preferences/dependencies/dependencies.ts:224
 #: src/lib/preferences/general/appExclusionSettings.ts:171
 #: src/lib/preferences/shortcuts/shortcutRow.ts:131
-#: src/lib/ui/components/editDialog.ts:314 src/lib/ui/indicator.ts:47
+#: src/lib/ui/components/editDialog.ts:315 src/lib/ui/indicator.ts:47
 msgid "Cancel"
 msgstr "Anuluj"
 
@@ -355,7 +350,7 @@ msgid "Edit Action"
 msgstr "Edytuj akcję"
 
 #: src/lib/preferences/actions/actionDialog.ts:662
-#: src/lib/ui/components/editDialog.ts:321
+#: src/lib/ui/components/editDialog.ts:322
 msgid "Save"
 msgstr "Zapisz"
 
@@ -1850,45 +1845,6 @@ msgstr "Schowek jest pusty"
 msgid "No Items Found"
 msgstr "Nie znaleziono elementów"
 
-<<<<<<< Updated upstream
-#: src/lib/ui/searchEntry.ts:150
-msgid "__All"
-msgstr "__Wszystko"
-
-#: src/lib/ui/searchEntry.ts:154
-msgid "__Text"
-msgstr "__Tekst"
-
-#: src/lib/ui/searchEntry.ts:155
-msgid "__Code"
-msgstr "__Kod"
-
-#: src/lib/ui/searchEntry.ts:156
-msgid "__Image"
-msgstr "__Obraz"
-
-#: src/lib/ui/searchEntry.ts:157
-msgid "__File"
-msgstr "__Plik"
-
-#: src/lib/ui/searchEntry.ts:158
-msgid "File__s"
-msgstr "Plik_i"
-
-#: src/lib/ui/searchEntry.ts:159
-msgid "__Link"
-msgstr "__Odnośnik"
-
-#: src/lib/ui/searchEntry.ts:160
-msgid "C__haracter"
-msgstr "Z_nak"
-
-#: src/lib/ui/searchEntry.ts:161
-msgid "Colo__r"
-msgstr "Kolo_r"
-
-#: src/lib/ui/searchEntry.ts:273
-=======
 #: src/lib/ui/searchEntry.ts:154
 msgid "__All"
 msgstr "__Wszystko"
@@ -1926,7 +1882,6 @@ msgid "Colo__r"
 msgstr "Kolo_r"
 
 #: src/lib/ui/searchEntry.ts:277
->>>>>>> Stashed changes
 msgid "Type to search"
 msgstr "Wpisz, aby wyszukać"
 

--- a/resources/po/pl.po
+++ b/resources/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-09 00:47-0300\n"
+"POT-Creation-Date: 2026-08-16 16:01-0300\n"
 "PO-Revision-Date: 2026-04-30 18:05+0200\n"
 "Last-Translator: Adam Lewicki <a.lewicki95@gmail.com>\n"
 "Language-Team: \n"
@@ -86,24 +86,24 @@ msgstr "Wyłącz ostrzeżenie"
 msgid "Failed to load JSON"
 msgstr "Błąd podczas ładowania pliku JSON"
 
-#: src/lib/misc/notifications.ts:63 src/lib/misc/notifications.ts:114
+#: src/lib/misc/notifications.ts:63 src/lib/misc/notifications.ts:125
 msgid "Copied Text"
 msgstr "Skopiowano tekst"
 
-#: src/lib/misc/notifications.ts:98 src/lib/misc/notifications.ts:123
+#: src/lib/misc/notifications.ts:109 src/lib/misc/notifications.ts:134
 msgid "Copied Image"
 msgstr "Skopiowano obraz"
 
-#: src/lib/misc/notifications.ts:99 src/lib/misc/notifications.ts:129
+#: src/lib/misc/notifications.ts:110 src/lib/misc/notifications.ts:140
 #, javascript-format
 msgid "Size: %d×%d px"
 msgstr "Rozmiar: %d×%d px"
 
-#: src/lib/misc/notifications.ts:118
+#: src/lib/misc/notifications.ts:129
 msgid "Copied Code"
 msgstr "Skopiowano kod"
 
-#: src/lib/misc/notifications.ts:142
+#: src/lib/misc/notifications.ts:153
 #, javascript-format
 msgid "Copied %d File"
 msgid_plural "Copied %d Files"
@@ -111,15 +111,15 @@ msgstr[0] "Skopiowany %d plik"
 msgstr[1] "Skopiowano %d pliki"
 msgstr[2] "Skopiowany %d plików"
 
-#: src/lib/misc/notifications.ts:148
+#: src/lib/misc/notifications.ts:159
 msgid "Copied Link"
 msgstr "Skopiowany odnośnik"
 
-#: src/lib/misc/notifications.ts:152
+#: src/lib/misc/notifications.ts:163
 msgid "Copied Character"
 msgstr "Skopiowany znak"
 
-#: src/lib/misc/notifications.ts:156
+#: src/lib/misc/notifications.ts:167
 msgid "Copied Color"
 msgstr "Skopiowany kolor"
 
@@ -1722,22 +1722,22 @@ msgstr "Wyłącz skrót klawiszowy"
 msgid "Disabled"
 msgstr "Wyłączono"
 
-#: src/lib/ui/components/contentInfo.ts:32
+#: src/lib/ui/components/contentInfo.ts:35
 #, javascript-format
 msgid "%dh"
 msgstr "%dgodz"
 
-#: src/lib/ui/components/contentInfo.ts:33
+#: src/lib/ui/components/contentInfo.ts:36
 #, javascript-format
 msgid "%dm"
 msgstr "%dm"
 
-#: src/lib/ui/components/contentInfo.ts:34
+#: src/lib/ui/components/contentInfo.ts:37
 #, javascript-format
 msgid "%ds"
 msgstr "%ds"
 
-#: src/lib/ui/components/contentInfo.ts:106
+#: src/lib/ui/components/contentInfo.ts:116
 #, javascript-format
 msgid "%d char"
 msgid_plural "%d chars"
@@ -1745,7 +1745,7 @@ msgstr[0] "%d znak"
 msgstr[1] "%d znaki"
 msgstr[2] "%d znaków"
 
-#: src/lib/ui/components/contentInfo.ts:114
+#: src/lib/ui/components/contentInfo.ts:123
 #, javascript-format
 msgid "%d word"
 msgid_plural "%d words"
@@ -1753,7 +1753,7 @@ msgstr[0] "%d słowo"
 msgstr[1] "%d słowa"
 msgstr[2] "%d słów"
 
-#: src/lib/ui/components/contentInfo.ts:117
+#: src/lib/ui/components/contentInfo.ts:126
 #, javascript-format
 msgid "%d line"
 msgid_plural "%d lines"
@@ -1761,11 +1761,11 @@ msgstr[0] "%d linia"
 msgstr[1] "%d linie"
 msgstr[2] "%d linii"
 
-#: src/lib/ui/components/contentInfo.ts:177
+#: src/lib/ui/components/contentInfo.ts:186
 msgid "Missing File"
 msgstr "Brakujący plik"
 
-#: src/lib/ui/components/contentInfo.ts:189
+#: src/lib/ui/components/contentInfo.ts:198
 msgid "Error"
 msgstr "Błąd"
 

--- a/resources/po/pt_BR.po
+++ b/resources/po/pt_BR.po
@@ -7,11 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-<<<<<<< Updated upstream
-"POT-Creation-Date: 2026-04-26 12:23-0500\n"
-=======
-"POT-Creation-Date: 2026-07-09 00:11-0300\n"
->>>>>>> Stashed changes
+"POT-Creation-Date: 2026-07-09 00:47-0300\n"
 "PO-Revision-Date: 2025-12-01 18:02-0300\n"
 "Last-Translator: Murilo Leal <murilormleal@outlook.com>\n"
 "Language-Team: Portuguese (Brazil)\n"
@@ -219,7 +215,7 @@ msgstr "Selecione quais tipos são permitidos"
 #: src/lib/preferences/dependencies/dependencies.ts:224
 #: src/lib/preferences/general/appExclusionSettings.ts:171
 #: src/lib/preferences/shortcuts/shortcutRow.ts:131
-#: src/lib/ui/components/editDialog.ts:314 src/lib/ui/indicator.ts:47
+#: src/lib/ui/components/editDialog.ts:315 src/lib/ui/indicator.ts:47
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -350,7 +346,7 @@ msgid "Edit Action"
 msgstr "Editar Ação"
 
 #: src/lib/preferences/actions/actionDialog.ts:662
-#: src/lib/ui/components/editDialog.ts:321
+#: src/lib/ui/components/editDialog.ts:322
 msgid "Save"
 msgstr "Salvar"
 
@@ -1834,45 +1830,6 @@ msgstr "Área de Transferência Vazia"
 msgid "No Items Found"
 msgstr "Nenhum item encontrado"
 
-<<<<<<< Updated upstream
-#: src/lib/ui/searchEntry.ts:150
-msgid "__All"
-msgstr "__Tudo"
-
-#: src/lib/ui/searchEntry.ts:154
-msgid "__Text"
-msgstr "__Texto"
-
-#: src/lib/ui/searchEntry.ts:155
-msgid "__Code"
-msgstr "__Código"
-
-#: src/lib/ui/searchEntry.ts:156
-msgid "__Image"
-msgstr "__Imagem"
-
-#: src/lib/ui/searchEntry.ts:157
-msgid "__File"
-msgstr "__Arquivo"
-
-#: src/lib/ui/searchEntry.ts:158
-msgid "File__s"
-msgstr "Arquivos__s"
-
-#: src/lib/ui/searchEntry.ts:159
-msgid "__Link"
-msgstr "__Link"
-
-#: src/lib/ui/searchEntry.ts:160
-msgid "C__haracter"
-msgstr "C__ractere"
-
-#: src/lib/ui/searchEntry.ts:161
-msgid "Colo__r"
-msgstr "Co__r"
-
-#: src/lib/ui/searchEntry.ts:273
-=======
 #: src/lib/ui/searchEntry.ts:154
 msgid "__All"
 msgstr "__Tudo"
@@ -1910,7 +1867,6 @@ msgid "Colo__r"
 msgstr "Co__r"
 
 #: src/lib/ui/searchEntry.ts:277
->>>>>>> Stashed changes
 msgid "Type to search"
 msgstr "Digite para pesquisar"
 

--- a/resources/po/pt_BR.po
+++ b/resources/po/pt_BR.po
@@ -7,7 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
+<<<<<<< Updated upstream
 "POT-Creation-Date: 2026-04-26 12:23-0500\n"
+=======
+"POT-Creation-Date: 2026-07-09 00:11-0300\n"
+>>>>>>> Stashed changes
 "PO-Revision-Date: 2025-12-01 18:02-0300\n"
 "Last-Translator: Murilo Leal <murilormleal@outlook.com>\n"
 "Language-Team: Portuguese (Brazil)\n"
@@ -124,8 +128,8 @@ msgstr "Cor copiada"
 #: src/lib/preferences/general/feedbackSettings.ts:259
 #: src/lib/preferences/general/feedbackSettings.ts:308
 #: src/lib/preferences/shortcuts/itemShortcuts.ts:39
-#: src/lib/ui/components/editDialog.ts:217
-#: src/lib/ui/components/editDialog.ts:244
+#: src/lib/ui/components/editDialog.ts:225
+#: src/lib/ui/components/editDialog.ts:252
 msgid "None"
 msgstr "Nenhum"
 
@@ -154,7 +158,7 @@ msgstr "Código"
 #: src/lib/preferences/actions/actionDialog.ts:177
 #: src/lib/preferences/actions/actionDialog.ts:370
 #: src/lib/preferences/customization/items/fileItemCustomization.ts:79
-#: src/lib/ui/items/imageItem.ts:38
+#: src/lib/ui/items/imageItem.ts:37
 msgid "Image"
 msgstr "Imagem"
 
@@ -168,7 +172,7 @@ msgstr "Arquivo"
 #: src/lib/preferences/actions/actionDefaults.ts:148
 #: src/lib/preferences/actions/actionDialog.ts:179
 #: src/lib/preferences/actions/actionDialog.ts:376
-#: src/lib/ui/items/filesItem.ts:140
+#: src/lib/ui/items/filesItem.ts:139
 msgid "Files"
 msgstr "Arquivos"
 
@@ -176,7 +180,7 @@ msgstr "Arquivos"
 #: src/lib/preferences/actions/actionDialog.ts:180
 #: src/lib/preferences/actions/actionDialog.ts:379
 #: src/lib/preferences/customization/items/linkItemCustomization.ts:45
-#: src/lib/ui/items/linkItem.ts:303
+#: src/lib/ui/items/linkItem.ts:304
 msgid "Link"
 msgstr "Link"
 
@@ -215,7 +219,7 @@ msgstr "Selecione quais tipos são permitidos"
 #: src/lib/preferences/dependencies/dependencies.ts:224
 #: src/lib/preferences/general/appExclusionSettings.ts:171
 #: src/lib/preferences/shortcuts/shortcutRow.ts:131
-#: src/lib/ui/components/editDialog.ts:306 src/lib/ui/indicator.ts:47
+#: src/lib/ui/components/editDialog.ts:314 src/lib/ui/indicator.ts:47
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -346,7 +350,7 @@ msgid "Edit Action"
 msgstr "Editar Ação"
 
 #: src/lib/preferences/actions/actionDialog.ts:662
-#: src/lib/ui/components/editDialog.ts:313
+#: src/lib/ui/components/editDialog.ts:321
 msgid "Save"
 msgstr "Salvar"
 
@@ -1490,7 +1494,7 @@ msgstr ""
 "fazer logout ou desligar o sistema"
 
 #: src/lib/preferences/general/historySettings.ts:137
-#: src/lib/ui/clipboardDialog.ts:130 src/lib/ui/clipboardDialog.ts:235
+#: src/lib/ui/clipboardDialog.ts:134 src/lib/ui/clipboardDialog.ts:239
 #: src/lib/ui/indicator.ts:54
 msgid "Clear"
 msgstr "Limpar"
@@ -1498,6 +1502,10 @@ msgstr "Limpar"
 #: src/lib/preferences/general/historySettings.ts:137
 msgid "Keep All"
 msgstr "Manter Todos"
+
+#: src/lib/preferences/general/historySettings.ts:137
+msgid "Keep Pinned"
+msgstr ""
 
 #: src/lib/preferences/general/historySettings.ts:137
 msgid "Keep Pinned/Tagged"
@@ -1753,7 +1761,7 @@ msgstr "Arquivo faltando"
 msgid "Error"
 msgstr "Erro"
 
-#: src/lib/ui/components/editDialog.ts:269
+#: src/lib/ui/components/editDialog.ts:277
 msgid "Edit Clipboard Item"
 msgstr "Editar Item da Área de Transferência"
 
@@ -1770,22 +1778,22 @@ msgid "Are you sure you want to clear your clipboard history?"
 msgstr "Tem certeza de que deseja limpar o histórico da área de transferência?"
 
 #: src/lib/ui/indicator.ts:43
-msgid "Clear Pinned/Tagged Items"
-msgstr "Limpar Itens Marcados"
+msgid "Clear Pinned Items"
+msgstr ""
 
-#: src/lib/ui/indicator.ts:102
+#: src/lib/ui/indicator.ts:99
 msgid "Incognito Mode"
 msgstr "Modo Anônimo"
 
-#: src/lib/ui/indicator.ts:105
+#: src/lib/ui/indicator.ts:102
 msgid "Clear History"
 msgstr "Limpar Histórico"
 
-#: src/lib/ui/indicator.ts:106
+#: src/lib/ui/indicator.ts:103
 msgid "Settings"
 msgstr "Configurações"
 
-#: src/lib/ui/indicator.ts:199
+#: src/lib/ui/indicator.ts:196
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -1796,14 +1804,14 @@ msgstr[1] "%d Arquivos"
 msgid "Char"
 msgstr "Caractere"
 
-#: src/lib/ui/items/filesItem.ts:120
+#: src/lib/ui/items/filesItem.ts:119
 #, javascript-format
 msgid "%d more file"
 msgid_plural "%d more files"
 msgstr[0] "%d mais arquivo"
 msgstr[1] "%d mais arquivos"
 
-#: src/lib/ui/items/filesItem.ts:121
+#: src/lib/ui/items/filesItem.ts:120
 #, javascript-format
 msgid "%d file"
 msgid_plural "%d files"
@@ -1826,6 +1834,7 @@ msgstr "Área de Transferência Vazia"
 msgid "No Items Found"
 msgstr "Nenhum item encontrado"
 
+<<<<<<< Updated upstream
 #: src/lib/ui/searchEntry.ts:150
 msgid "__All"
 msgstr "__Tudo"
@@ -1863,6 +1872,45 @@ msgid "Colo__r"
 msgstr "Co__r"
 
 #: src/lib/ui/searchEntry.ts:273
+=======
+#: src/lib/ui/searchEntry.ts:154
+msgid "__All"
+msgstr "__Tudo"
+
+#: src/lib/ui/searchEntry.ts:158
+msgid "__Text"
+msgstr "__Texto"
+
+#: src/lib/ui/searchEntry.ts:159
+msgid "__Code"
+msgstr "__Código"
+
+#: src/lib/ui/searchEntry.ts:160
+msgid "__Image"
+msgstr "__Imagem"
+
+#: src/lib/ui/searchEntry.ts:161
+msgid "__File"
+msgstr "__Arquivo"
+
+#: src/lib/ui/searchEntry.ts:162
+msgid "File__s"
+msgstr "Arquivos__s"
+
+#: src/lib/ui/searchEntry.ts:163
+msgid "__Link"
+msgstr "__Link"
+
+#: src/lib/ui/searchEntry.ts:164
+msgid "C__haracter"
+msgstr "C__ractere"
+
+#: src/lib/ui/searchEntry.ts:165
+msgid "Colo__r"
+msgstr "Co__r"
+
+#: src/lib/ui/searchEntry.ts:277
+>>>>>>> Stashed changes
 msgid "Type to search"
 msgstr "Digite para pesquisar"
 

--- a/resources/po/pt_BR.po
+++ b/resources/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-09 00:47-0300\n"
+"POT-Creation-Date: 2026-08-16 16:01-0300\n"
 "PO-Revision-Date: 2025-12-01 18:02-0300\n"
 "Last-Translator: Murilo Leal <murilormleal@outlook.com>\n"
 "Language-Team: Portuguese (Brazil)\n"
@@ -83,39 +83,39 @@ msgstr "Desativar aviso"
 msgid "Failed to load JSON"
 msgstr ""
 
-#: src/lib/misc/notifications.ts:63 src/lib/misc/notifications.ts:114
+#: src/lib/misc/notifications.ts:63 src/lib/misc/notifications.ts:125
 msgid "Copied Text"
 msgstr "Texto copiado"
 
-#: src/lib/misc/notifications.ts:98 src/lib/misc/notifications.ts:123
+#: src/lib/misc/notifications.ts:109 src/lib/misc/notifications.ts:134
 msgid "Copied Image"
 msgstr "Imagem copiada"
 
-#: src/lib/misc/notifications.ts:99 src/lib/misc/notifications.ts:129
+#: src/lib/misc/notifications.ts:110 src/lib/misc/notifications.ts:140
 #, javascript-format
 msgid "Size: %d×%d px"
 msgstr "Tamanho: %d×%d px"
 
-#: src/lib/misc/notifications.ts:118
+#: src/lib/misc/notifications.ts:129
 msgid "Copied Code"
 msgstr "Código copiado"
 
-#: src/lib/misc/notifications.ts:142
+#: src/lib/misc/notifications.ts:153
 #, javascript-format
 msgid "Copied %d File"
 msgid_plural "Copied %d Files"
 msgstr[0] "Arquivo %d copiado"
 msgstr[1] "Arquivos %d copiados"
 
-#: src/lib/misc/notifications.ts:148
+#: src/lib/misc/notifications.ts:159
 msgid "Copied Link"
 msgstr "Link copiado"
 
-#: src/lib/misc/notifications.ts:152
+#: src/lib/misc/notifications.ts:163
 msgid "Copied Character"
 msgstr "Caractere copiado"
 
-#: src/lib/misc/notifications.ts:156
+#: src/lib/misc/notifications.ts:167
 msgid "Copied Color"
 msgstr "Cor copiada"
 
@@ -1713,47 +1713,47 @@ msgstr "Desativar Atalho"
 msgid "Disabled"
 msgstr "Desabilitado"
 
-#: src/lib/ui/components/contentInfo.ts:32
+#: src/lib/ui/components/contentInfo.ts:35
 #, javascript-format
 msgid "%dh"
 msgstr "%dh"
 
-#: src/lib/ui/components/contentInfo.ts:33
+#: src/lib/ui/components/contentInfo.ts:36
 #, javascript-format
 msgid "%dm"
 msgstr "%dm"
 
-#: src/lib/ui/components/contentInfo.ts:34
+#: src/lib/ui/components/contentInfo.ts:37
 #, javascript-format
 msgid "%ds"
 msgstr "%ds"
 
-#: src/lib/ui/components/contentInfo.ts:106
+#: src/lib/ui/components/contentInfo.ts:116
 #, javascript-format
 msgid "%d char"
 msgid_plural "%d chars"
 msgstr[0] "%d caractere"
 msgstr[1] "%d caracteres"
 
-#: src/lib/ui/components/contentInfo.ts:114
+#: src/lib/ui/components/contentInfo.ts:123
 #, javascript-format
 msgid "%d word"
 msgid_plural "%d words"
 msgstr[0] "%d palavra"
 msgstr[1] "%d palavras"
 
-#: src/lib/ui/components/contentInfo.ts:117
+#: src/lib/ui/components/contentInfo.ts:126
 #, javascript-format
 msgid "%d line"
 msgid_plural "%d lines"
 msgstr[0] "%d linha"
 msgstr[1] "%d linhas"
 
-#: src/lib/ui/components/contentInfo.ts:177
+#: src/lib/ui/components/contentInfo.ts:186
 msgid "Missing File"
 msgstr "Arquivo faltando"
 
-#: src/lib/ui/components/contentInfo.ts:189
+#: src/lib/ui/components/contentInfo.ts:198
 msgid "Error"
 msgstr "Erro"
 

--- a/resources/po/ru.po
+++ b/resources/po/ru.po
@@ -8,11 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-<<<<<<< Updated upstream
-"POT-Creation-Date: 2026-04-26 12:23-0500\n"
-=======
-"POT-Creation-Date: 2026-07-09 00:11-0300\n"
->>>>>>> Stashed changes
+"POT-Creation-Date: 2026-07-09 00:47-0300\n"
 "PO-Revision-Date: 2025-11-30 20:29+0700\n"
 "Last-Translator: Victor <firephantom303@gmail.com>\n"
 "Language-Team: Russian\n"
@@ -223,7 +219,7 @@ msgstr "Выберите, какие типы разрешены"
 #: src/lib/preferences/dependencies/dependencies.ts:224
 #: src/lib/preferences/general/appExclusionSettings.ts:171
 #: src/lib/preferences/shortcuts/shortcutRow.ts:131
-#: src/lib/ui/components/editDialog.ts:314 src/lib/ui/indicator.ts:47
+#: src/lib/ui/components/editDialog.ts:315 src/lib/ui/indicator.ts:47
 msgid "Cancel"
 msgstr "Отмена"
 
@@ -354,7 +350,7 @@ msgid "Edit Action"
 msgstr "Изменить действие"
 
 #: src/lib/preferences/actions/actionDialog.ts:662
-#: src/lib/ui/components/editDialog.ts:321
+#: src/lib/ui/components/editDialog.ts:322
 msgid "Save"
 msgstr "Сохранить"
 
@@ -1833,45 +1829,6 @@ msgstr "Буфер обмена пуст"
 msgid "No Items Found"
 msgstr "Элементы не найдены"
 
-<<<<<<< Updated upstream
-#: src/lib/ui/searchEntry.ts:150
-msgid "__All"
-msgstr "__Все"
-
-#: src/lib/ui/searchEntry.ts:154
-msgid "__Text"
-msgstr "__Текст"
-
-#: src/lib/ui/searchEntry.ts:155
-msgid "__Code"
-msgstr "__Код"
-
-#: src/lib/ui/searchEntry.ts:156
-msgid "__Image"
-msgstr "__Изобр"
-
-#: src/lib/ui/searchEntry.ts:157
-msgid "__File"
-msgstr "__Файл"
-
-#: src/lib/ui/searchEntry.ts:158
-msgid "File__s"
-msgstr "Фай__лы"
-
-#: src/lib/ui/searchEntry.ts:159
-msgid "__Link"
-msgstr "__Ссылка"
-
-#: src/lib/ui/searchEntry.ts:160
-msgid "C__haracter"
-msgstr "С__имвол"
-
-#: src/lib/ui/searchEntry.ts:161
-msgid "Colo__r"
-msgstr "Цв__ет"
-
-#: src/lib/ui/searchEntry.ts:273
-=======
 #: src/lib/ui/searchEntry.ts:154
 msgid "__All"
 msgstr "__Все"
@@ -1909,7 +1866,6 @@ msgid "Colo__r"
 msgstr "Цв__ет"
 
 #: src/lib/ui/searchEntry.ts:277
->>>>>>> Stashed changes
 msgid "Type to search"
 msgstr "Введите текст для поиска"
 

--- a/resources/po/ru.po
+++ b/resources/po/ru.po
@@ -8,7 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
+<<<<<<< Updated upstream
 "POT-Creation-Date: 2026-04-26 12:23-0500\n"
+=======
+"POT-Creation-Date: 2026-07-09 00:11-0300\n"
+>>>>>>> Stashed changes
 "PO-Revision-Date: 2025-11-30 20:29+0700\n"
 "Last-Translator: Victor <firephantom303@gmail.com>\n"
 "Language-Team: Russian\n"
@@ -128,8 +132,8 @@ msgstr "Скопирован цвет"
 #: src/lib/preferences/general/feedbackSettings.ts:259
 #: src/lib/preferences/general/feedbackSettings.ts:308
 #: src/lib/preferences/shortcuts/itemShortcuts.ts:39
-#: src/lib/ui/components/editDialog.ts:217
-#: src/lib/ui/components/editDialog.ts:244
+#: src/lib/ui/components/editDialog.ts:225
+#: src/lib/ui/components/editDialog.ts:252
 msgid "None"
 msgstr "Нет"
 
@@ -158,7 +162,7 @@ msgstr "Код"
 #: src/lib/preferences/actions/actionDialog.ts:177
 #: src/lib/preferences/actions/actionDialog.ts:370
 #: src/lib/preferences/customization/items/fileItemCustomization.ts:79
-#: src/lib/ui/items/imageItem.ts:38
+#: src/lib/ui/items/imageItem.ts:37
 msgid "Image"
 msgstr "Изображение"
 
@@ -172,7 +176,7 @@ msgstr "Файл"
 #: src/lib/preferences/actions/actionDefaults.ts:148
 #: src/lib/preferences/actions/actionDialog.ts:179
 #: src/lib/preferences/actions/actionDialog.ts:376
-#: src/lib/ui/items/filesItem.ts:140
+#: src/lib/ui/items/filesItem.ts:139
 msgid "Files"
 msgstr "Файлы"
 
@@ -180,7 +184,7 @@ msgstr "Файлы"
 #: src/lib/preferences/actions/actionDialog.ts:180
 #: src/lib/preferences/actions/actionDialog.ts:379
 #: src/lib/preferences/customization/items/linkItemCustomization.ts:45
-#: src/lib/ui/items/linkItem.ts:303
+#: src/lib/ui/items/linkItem.ts:304
 msgid "Link"
 msgstr "Ссылка"
 
@@ -219,7 +223,7 @@ msgstr "Выберите, какие типы разрешены"
 #: src/lib/preferences/dependencies/dependencies.ts:224
 #: src/lib/preferences/general/appExclusionSettings.ts:171
 #: src/lib/preferences/shortcuts/shortcutRow.ts:131
-#: src/lib/ui/components/editDialog.ts:306 src/lib/ui/indicator.ts:47
+#: src/lib/ui/components/editDialog.ts:314 src/lib/ui/indicator.ts:47
 msgid "Cancel"
 msgstr "Отмена"
 
@@ -350,7 +354,7 @@ msgid "Edit Action"
 msgstr "Изменить действие"
 
 #: src/lib/preferences/actions/actionDialog.ts:662
-#: src/lib/ui/components/editDialog.ts:313
+#: src/lib/ui/components/editDialog.ts:321
 msgid "Save"
 msgstr "Сохранить"
 
@@ -1483,7 +1487,7 @@ msgstr ""
 "системы или её завершении"
 
 #: src/lib/preferences/general/historySettings.ts:137
-#: src/lib/ui/clipboardDialog.ts:130 src/lib/ui/clipboardDialog.ts:235
+#: src/lib/ui/clipboardDialog.ts:134 src/lib/ui/clipboardDialog.ts:239
 #: src/lib/ui/indicator.ts:54
 msgid "Clear"
 msgstr "Очистить"
@@ -1491,6 +1495,10 @@ msgstr "Очистить"
 #: src/lib/preferences/general/historySettings.ts:137
 msgid "Keep All"
 msgstr "Сохранять всё"
+
+#: src/lib/preferences/general/historySettings.ts:137
+msgid "Keep Pinned"
+msgstr ""
 
 #: src/lib/preferences/general/historySettings.ts:137
 msgid "Keep Pinned/Tagged"
@@ -1749,7 +1757,7 @@ msgstr "Файл отсутствует"
 msgid "Error"
 msgstr "Ошибка"
 
-#: src/lib/ui/components/editDialog.ts:269
+#: src/lib/ui/components/editDialog.ts:277
 msgid "Edit Clipboard Item"
 msgstr "Редактировать элемент буфера обмена"
 
@@ -1766,22 +1774,22 @@ msgid "Are you sure you want to clear your clipboard history?"
 msgstr "Действительно очистить историю буфера обмена?"
 
 #: src/lib/ui/indicator.ts:43
-msgid "Clear Pinned/Tagged Items"
-msgstr "Очистить закреплённые/помеченные элементы"
+msgid "Clear Pinned Items"
+msgstr ""
 
-#: src/lib/ui/indicator.ts:102
+#: src/lib/ui/indicator.ts:99
 msgid "Incognito Mode"
 msgstr "Режим инкогнито"
 
-#: src/lib/ui/indicator.ts:105
+#: src/lib/ui/indicator.ts:102
 msgid "Clear History"
 msgstr "Очистить историю"
 
-#: src/lib/ui/indicator.ts:106
+#: src/lib/ui/indicator.ts:103
 msgid "Settings"
 msgstr "Настройки"
 
-#: src/lib/ui/indicator.ts:199
+#: src/lib/ui/indicator.ts:196
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -1793,7 +1801,7 @@ msgstr[2] ""
 msgid "Char"
 msgstr "Символ"
 
-#: src/lib/ui/items/filesItem.ts:120
+#: src/lib/ui/items/filesItem.ts:119
 #, javascript-format
 msgid "%d more file"
 msgid_plural "%d more files"
@@ -1801,7 +1809,7 @@ msgstr[0] "ещё %d файл"
 msgstr[1] "ещё %d файла"
 msgstr[2] "ещё %d файлов"
 
-#: src/lib/ui/items/filesItem.ts:121
+#: src/lib/ui/items/filesItem.ts:120
 #, javascript-format
 msgid "%d file"
 msgid_plural "%d files"
@@ -1825,6 +1833,7 @@ msgstr "Буфер обмена пуст"
 msgid "No Items Found"
 msgstr "Элементы не найдены"
 
+<<<<<<< Updated upstream
 #: src/lib/ui/searchEntry.ts:150
 msgid "__All"
 msgstr "__Все"
@@ -1862,6 +1871,45 @@ msgid "Colo__r"
 msgstr "Цв__ет"
 
 #: src/lib/ui/searchEntry.ts:273
+=======
+#: src/lib/ui/searchEntry.ts:154
+msgid "__All"
+msgstr "__Все"
+
+#: src/lib/ui/searchEntry.ts:158
+msgid "__Text"
+msgstr "__Текст"
+
+#: src/lib/ui/searchEntry.ts:159
+msgid "__Code"
+msgstr "__Код"
+
+#: src/lib/ui/searchEntry.ts:160
+msgid "__Image"
+msgstr "__Изобр"
+
+#: src/lib/ui/searchEntry.ts:161
+msgid "__File"
+msgstr "__Файл"
+
+#: src/lib/ui/searchEntry.ts:162
+msgid "File__s"
+msgstr "Фай__лы"
+
+#: src/lib/ui/searchEntry.ts:163
+msgid "__Link"
+msgstr "__Ссылка"
+
+#: src/lib/ui/searchEntry.ts:164
+msgid "C__haracter"
+msgstr "С__имвол"
+
+#: src/lib/ui/searchEntry.ts:165
+msgid "Colo__r"
+msgstr "Цв__ет"
+
+#: src/lib/ui/searchEntry.ts:277
+>>>>>>> Stashed changes
 msgid "Type to search"
 msgstr "Введите текст для поиска"
 

--- a/resources/po/ru.po
+++ b/resources/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-09 00:47-0300\n"
+"POT-Creation-Date: 2026-08-16 16:01-0300\n"
 "PO-Revision-Date: 2025-11-30 20:29+0700\n"
 "Last-Translator: Victor <firephantom303@gmail.com>\n"
 "Language-Team: Russian\n"
@@ -86,24 +86,24 @@ msgstr "Отключить предупреждение"
 msgid "Failed to load JSON"
 msgstr ""
 
-#: src/lib/misc/notifications.ts:63 src/lib/misc/notifications.ts:114
+#: src/lib/misc/notifications.ts:63 src/lib/misc/notifications.ts:125
 msgid "Copied Text"
 msgstr "Скопирован текст"
 
-#: src/lib/misc/notifications.ts:98 src/lib/misc/notifications.ts:123
+#: src/lib/misc/notifications.ts:109 src/lib/misc/notifications.ts:134
 msgid "Copied Image"
 msgstr "Скопировано изображение"
 
-#: src/lib/misc/notifications.ts:99 src/lib/misc/notifications.ts:129
+#: src/lib/misc/notifications.ts:110 src/lib/misc/notifications.ts:140
 #, javascript-format
 msgid "Size: %d×%d px"
 msgstr "Размер: %d×%d пикс"
 
-#: src/lib/misc/notifications.ts:118
+#: src/lib/misc/notifications.ts:129
 msgid "Copied Code"
 msgstr "Скопирован код"
 
-#: src/lib/misc/notifications.ts:142
+#: src/lib/misc/notifications.ts:153
 #, javascript-format
 msgid "Copied %d File"
 msgid_plural "Copied %d Files"
@@ -111,15 +111,15 @@ msgstr[0] "Скопирован %d файл"
 msgstr[1] "Скопировано %d файла"
 msgstr[2] "Скопировано %d файлов"
 
-#: src/lib/misc/notifications.ts:148
+#: src/lib/misc/notifications.ts:159
 msgid "Copied Link"
 msgstr "Скопирована ссылка"
 
-#: src/lib/misc/notifications.ts:152
+#: src/lib/misc/notifications.ts:163
 msgid "Copied Character"
 msgstr "Скопирован символ"
 
-#: src/lib/misc/notifications.ts:156
+#: src/lib/misc/notifications.ts:167
 msgid "Copied Color"
 msgstr "Скопирован цвет"
 
@@ -1706,22 +1706,22 @@ msgstr "Отключить сочетание клавиш"
 msgid "Disabled"
 msgstr "Отключено"
 
-#: src/lib/ui/components/contentInfo.ts:32
+#: src/lib/ui/components/contentInfo.ts:35
 #, javascript-format
 msgid "%dh"
 msgstr ""
 
-#: src/lib/ui/components/contentInfo.ts:33
+#: src/lib/ui/components/contentInfo.ts:36
 #, javascript-format
 msgid "%dm"
 msgstr ""
 
-#: src/lib/ui/components/contentInfo.ts:34
+#: src/lib/ui/components/contentInfo.ts:37
 #, javascript-format
 msgid "%ds"
 msgstr ""
 
-#: src/lib/ui/components/contentInfo.ts:106
+#: src/lib/ui/components/contentInfo.ts:116
 #, javascript-format
 msgid "%d char"
 msgid_plural "%d chars"
@@ -1729,7 +1729,7 @@ msgstr[0] "%d символ"
 msgstr[1] "%d символа"
 msgstr[2] "%d символов"
 
-#: src/lib/ui/components/contentInfo.ts:114
+#: src/lib/ui/components/contentInfo.ts:123
 #, javascript-format
 msgid "%d word"
 msgid_plural "%d words"
@@ -1737,7 +1737,7 @@ msgstr[0] "%d слово"
 msgstr[1] "%d слова"
 msgstr[2] "%d слов"
 
-#: src/lib/ui/components/contentInfo.ts:117
+#: src/lib/ui/components/contentInfo.ts:126
 #, javascript-format
 msgid "%d line"
 msgid_plural "%d lines"
@@ -1745,11 +1745,11 @@ msgstr[0] "%d строка"
 msgstr[1] "%d строки"
 msgstr[2] "%d строк"
 
-#: src/lib/ui/components/contentInfo.ts:177
+#: src/lib/ui/components/contentInfo.ts:186
 msgid "Missing File"
 msgstr "Файл отсутствует"
 
-#: src/lib/ui/components/contentInfo.ts:189
+#: src/lib/ui/components/contentInfo.ts:198
 msgid "Error"
 msgstr "Ошибка"
 

--- a/resources/po/tr.po
+++ b/resources/po/tr.po
@@ -8,11 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-<<<<<<< Updated upstream
-"POT-Creation-Date: 2026-04-26 12:23-0500\n"
-=======
-"POT-Creation-Date: 2026-07-09 00:11-0300\n"
->>>>>>> Stashed changes
+"POT-Creation-Date: 2026-07-09 00:47-0300\n"
 "PO-Revision-Date: 2026-03-18 07:29+0300\n"
 "Last-Translator: Muha Aliss <muhaaliss@pm.me>\n"
 "Language-Team: Turkish\n"
@@ -221,7 +217,7 @@ msgstr "Hangi türlere izin verileceğini seç"
 #: src/lib/preferences/dependencies/dependencies.ts:224
 #: src/lib/preferences/general/appExclusionSettings.ts:171
 #: src/lib/preferences/shortcuts/shortcutRow.ts:131
-#: src/lib/ui/components/editDialog.ts:314 src/lib/ui/indicator.ts:47
+#: src/lib/ui/components/editDialog.ts:315 src/lib/ui/indicator.ts:47
 msgid "Cancel"
 msgstr "İptal"
 
@@ -351,7 +347,7 @@ msgid "Edit Action"
 msgstr "Eylemi Düzenle"
 
 #: src/lib/preferences/actions/actionDialog.ts:662
-#: src/lib/ui/components/editDialog.ts:321
+#: src/lib/ui/components/editDialog.ts:322
 msgid "Save"
 msgstr "Kaydet"
 
@@ -1834,45 +1830,6 @@ msgstr "Pano Boş"
 msgid "No Items Found"
 msgstr "Öğe Bulunamadı"
 
-<<<<<<< Updated upstream
-#: src/lib/ui/searchEntry.ts:150
-msgid "__All"
-msgstr "__Hepsi"
-
-#: src/lib/ui/searchEntry.ts:154
-msgid "__Text"
-msgstr "__Metin"
-
-#: src/lib/ui/searchEntry.ts:155
-msgid "__Code"
-msgstr "__Kod"
-
-#: src/lib/ui/searchEntry.ts:156
-msgid "__Image"
-msgstr "__Resim"
-
-#: src/lib/ui/searchEntry.ts:157
-msgid "__File"
-msgstr "__Dosya"
-
-#: src/lib/ui/searchEntry.ts:158
-msgid "File__s"
-msgstr "Dosy__alar"
-
-#: src/lib/ui/searchEntry.ts:159
-msgid "__Link"
-msgstr "__Bağlantı"
-
-#: src/lib/ui/searchEntry.ts:160
-msgid "C__haracter"
-msgstr "K__arakter"
-
-#: src/lib/ui/searchEntry.ts:161
-msgid "Colo__r"
-msgstr "Re__nk"
-
-#: src/lib/ui/searchEntry.ts:273
-=======
 #: src/lib/ui/searchEntry.ts:154
 msgid "__All"
 msgstr "__Hepsi"
@@ -1910,7 +1867,6 @@ msgid "Colo__r"
 msgstr "Re__nk"
 
 #: src/lib/ui/searchEntry.ts:277
->>>>>>> Stashed changes
 msgid "Type to search"
 msgstr "Aramak için yaz"
 

--- a/resources/po/tr.po
+++ b/resources/po/tr.po
@@ -8,7 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
+<<<<<<< Updated upstream
 "POT-Creation-Date: 2026-04-26 12:23-0500\n"
+=======
+"POT-Creation-Date: 2026-07-09 00:11-0300\n"
+>>>>>>> Stashed changes
 "PO-Revision-Date: 2026-03-18 07:29+0300\n"
 "Last-Translator: Muha Aliss <muhaaliss@pm.me>\n"
 "Language-Team: Turkish\n"
@@ -126,8 +130,8 @@ msgstr "Renk Kopyalandı"
 #: src/lib/preferences/general/feedbackSettings.ts:259
 #: src/lib/preferences/general/feedbackSettings.ts:308
 #: src/lib/preferences/shortcuts/itemShortcuts.ts:39
-#: src/lib/ui/components/editDialog.ts:217
-#: src/lib/ui/components/editDialog.ts:244
+#: src/lib/ui/components/editDialog.ts:225
+#: src/lib/ui/components/editDialog.ts:252
 msgid "None"
 msgstr "Hiçbiri"
 
@@ -156,7 +160,7 @@ msgstr "Kod"
 #: src/lib/preferences/actions/actionDialog.ts:177
 #: src/lib/preferences/actions/actionDialog.ts:370
 #: src/lib/preferences/customization/items/fileItemCustomization.ts:79
-#: src/lib/ui/items/imageItem.ts:38
+#: src/lib/ui/items/imageItem.ts:37
 msgid "Image"
 msgstr "Resim"
 
@@ -170,7 +174,7 @@ msgstr "Dosya"
 #: src/lib/preferences/actions/actionDefaults.ts:148
 #: src/lib/preferences/actions/actionDialog.ts:179
 #: src/lib/preferences/actions/actionDialog.ts:376
-#: src/lib/ui/items/filesItem.ts:140
+#: src/lib/ui/items/filesItem.ts:139
 msgid "Files"
 msgstr "Dosyalar"
 
@@ -178,7 +182,7 @@ msgstr "Dosyalar"
 #: src/lib/preferences/actions/actionDialog.ts:180
 #: src/lib/preferences/actions/actionDialog.ts:379
 #: src/lib/preferences/customization/items/linkItemCustomization.ts:45
-#: src/lib/ui/items/linkItem.ts:303
+#: src/lib/ui/items/linkItem.ts:304
 msgid "Link"
 msgstr "Bağlantı"
 
@@ -217,7 +221,7 @@ msgstr "Hangi türlere izin verileceğini seç"
 #: src/lib/preferences/dependencies/dependencies.ts:224
 #: src/lib/preferences/general/appExclusionSettings.ts:171
 #: src/lib/preferences/shortcuts/shortcutRow.ts:131
-#: src/lib/ui/components/editDialog.ts:306 src/lib/ui/indicator.ts:47
+#: src/lib/ui/components/editDialog.ts:314 src/lib/ui/indicator.ts:47
 msgid "Cancel"
 msgstr "İptal"
 
@@ -347,7 +351,7 @@ msgid "Edit Action"
 msgstr "Eylemi Düzenle"
 
 #: src/lib/preferences/actions/actionDialog.ts:662
-#: src/lib/ui/components/editDialog.ts:313
+#: src/lib/ui/components/editDialog.ts:321
 msgid "Save"
 msgstr "Kaydet"
 
@@ -1488,7 +1492,7 @@ msgstr ""
 "pano geçmişine ne yapılacağını seç"
 
 #: src/lib/preferences/general/historySettings.ts:137
-#: src/lib/ui/clipboardDialog.ts:130 src/lib/ui/clipboardDialog.ts:235
+#: src/lib/ui/clipboardDialog.ts:134 src/lib/ui/clipboardDialog.ts:239
 #: src/lib/ui/indicator.ts:54
 msgid "Clear"
 msgstr "Temizle"
@@ -1496,6 +1500,10 @@ msgstr "Temizle"
 #: src/lib/preferences/general/historySettings.ts:137
 msgid "Keep All"
 msgstr "Hepsini Koru"
+
+#: src/lib/preferences/general/historySettings.ts:137
+msgid "Keep Pinned"
+msgstr ""
 
 #: src/lib/preferences/general/historySettings.ts:137
 msgid "Keep Pinned/Tagged"
@@ -1753,7 +1761,7 @@ msgstr "Eksik Dosya"
 msgid "Error"
 msgstr "Hata"
 
-#: src/lib/ui/components/editDialog.ts:269
+#: src/lib/ui/components/editDialog.ts:277
 msgid "Edit Clipboard Item"
 msgstr "Pano Öğesini Düzenle"
 
@@ -1770,22 +1778,22 @@ msgid "Are you sure you want to clear your clipboard history?"
 msgstr "Pano geçmişinizi temizlemek istediğinden emin misin?"
 
 #: src/lib/ui/indicator.ts:43
-msgid "Clear Pinned/Tagged Items"
-msgstr "İğnelenen/Etiketlenen Öğeleri Temizle"
+msgid "Clear Pinned Items"
+msgstr ""
 
-#: src/lib/ui/indicator.ts:102
+#: src/lib/ui/indicator.ts:99
 msgid "Incognito Mode"
 msgstr "Gizli Mod"
 
-#: src/lib/ui/indicator.ts:105
+#: src/lib/ui/indicator.ts:102
 msgid "Clear History"
 msgstr "Geçmişi Temizle"
 
-#: src/lib/ui/indicator.ts:106
+#: src/lib/ui/indicator.ts:103
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: src/lib/ui/indicator.ts:199
+#: src/lib/ui/indicator.ts:196
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -1796,14 +1804,14 @@ msgstr[1] "%d Dosya"
 msgid "Char"
 msgstr "Karakter"
 
-#: src/lib/ui/items/filesItem.ts:120
+#: src/lib/ui/items/filesItem.ts:119
 #, javascript-format
 msgid "%d more file"
 msgid_plural "%d more files"
 msgstr[0] "%d dosya daha"
 msgstr[1] "%d dosya daha"
 
-#: src/lib/ui/items/filesItem.ts:121
+#: src/lib/ui/items/filesItem.ts:120
 #, javascript-format
 msgid "%d file"
 msgid_plural "%d files"
@@ -1826,6 +1834,7 @@ msgstr "Pano Boş"
 msgid "No Items Found"
 msgstr "Öğe Bulunamadı"
 
+<<<<<<< Updated upstream
 #: src/lib/ui/searchEntry.ts:150
 msgid "__All"
 msgstr "__Hepsi"
@@ -1863,6 +1872,45 @@ msgid "Colo__r"
 msgstr "Re__nk"
 
 #: src/lib/ui/searchEntry.ts:273
+=======
+#: src/lib/ui/searchEntry.ts:154
+msgid "__All"
+msgstr "__Hepsi"
+
+#: src/lib/ui/searchEntry.ts:158
+msgid "__Text"
+msgstr "__Metin"
+
+#: src/lib/ui/searchEntry.ts:159
+msgid "__Code"
+msgstr "__Kod"
+
+#: src/lib/ui/searchEntry.ts:160
+msgid "__Image"
+msgstr "__Resim"
+
+#: src/lib/ui/searchEntry.ts:161
+msgid "__File"
+msgstr "__Dosya"
+
+#: src/lib/ui/searchEntry.ts:162
+msgid "File__s"
+msgstr "Dosy__alar"
+
+#: src/lib/ui/searchEntry.ts:163
+msgid "__Link"
+msgstr "__Bağlantı"
+
+#: src/lib/ui/searchEntry.ts:164
+msgid "C__haracter"
+msgstr "K__arakter"
+
+#: src/lib/ui/searchEntry.ts:165
+msgid "Colo__r"
+msgstr "Re__nk"
+
+#: src/lib/ui/searchEntry.ts:277
+>>>>>>> Stashed changes
 msgid "Type to search"
 msgstr "Aramak için yaz"
 

--- a/resources/po/tr.po
+++ b/resources/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-09 00:47-0300\n"
+"POT-Creation-Date: 2026-08-16 16:01-0300\n"
 "PO-Revision-Date: 2026-03-18 07:29+0300\n"
 "Last-Translator: Muha Aliss <muhaaliss@pm.me>\n"
 "Language-Team: Turkish\n"
@@ -85,39 +85,39 @@ msgstr "Uyarıyı Devre Dışı Bırak"
 msgid "Failed to load JSON"
 msgstr ""
 
-#: src/lib/misc/notifications.ts:63 src/lib/misc/notifications.ts:114
+#: src/lib/misc/notifications.ts:63 src/lib/misc/notifications.ts:125
 msgid "Copied Text"
 msgstr "Metin Kopyalandı"
 
-#: src/lib/misc/notifications.ts:98 src/lib/misc/notifications.ts:123
+#: src/lib/misc/notifications.ts:109 src/lib/misc/notifications.ts:134
 msgid "Copied Image"
 msgstr "Resim Kopyalandı"
 
-#: src/lib/misc/notifications.ts:99 src/lib/misc/notifications.ts:129
+#: src/lib/misc/notifications.ts:110 src/lib/misc/notifications.ts:140
 #, javascript-format
 msgid "Size: %d×%d px"
 msgstr "Boyut: %d×%d px"
 
-#: src/lib/misc/notifications.ts:118
+#: src/lib/misc/notifications.ts:129
 msgid "Copied Code"
 msgstr "Kod Kopyalandı"
 
-#: src/lib/misc/notifications.ts:142
+#: src/lib/misc/notifications.ts:153
 #, javascript-format
 msgid "Copied %d File"
 msgid_plural "Copied %d Files"
 msgstr[0] "%d Dosya Kopyalandı"
 msgstr[1] "%d Dosya Kopyalandı"
 
-#: src/lib/misc/notifications.ts:148
+#: src/lib/misc/notifications.ts:159
 msgid "Copied Link"
 msgstr "Bağlantı Kopyalandı"
 
-#: src/lib/misc/notifications.ts:152
+#: src/lib/misc/notifications.ts:163
 msgid "Copied Character"
 msgstr "Karakter Kopyalandı"
 
-#: src/lib/misc/notifications.ts:156
+#: src/lib/misc/notifications.ts:167
 msgid "Copied Color"
 msgstr "Renk Kopyalandı"
 
@@ -1713,47 +1713,47 @@ msgstr "Kısayolu Devre Dışı Bırak"
 msgid "Disabled"
 msgstr "Devre Dışı"
 
-#: src/lib/ui/components/contentInfo.ts:32
+#: src/lib/ui/components/contentInfo.ts:35
 #, javascript-format
 msgid "%dh"
 msgstr "%d sa"
 
-#: src/lib/ui/components/contentInfo.ts:33
+#: src/lib/ui/components/contentInfo.ts:36
 #, javascript-format
 msgid "%dm"
 msgstr "%d dk"
 
-#: src/lib/ui/components/contentInfo.ts:34
+#: src/lib/ui/components/contentInfo.ts:37
 #, javascript-format
 msgid "%ds"
 msgstr "%d sn"
 
-#: src/lib/ui/components/contentInfo.ts:106
+#: src/lib/ui/components/contentInfo.ts:116
 #, javascript-format
 msgid "%d char"
 msgid_plural "%d chars"
 msgstr[0] "%d karakter"
 msgstr[1] "%d karakter"
 
-#: src/lib/ui/components/contentInfo.ts:114
+#: src/lib/ui/components/contentInfo.ts:123
 #, javascript-format
 msgid "%d word"
 msgid_plural "%d words"
 msgstr[0] "%d kelime"
 msgstr[1] "%d kelime"
 
-#: src/lib/ui/components/contentInfo.ts:117
+#: src/lib/ui/components/contentInfo.ts:126
 #, javascript-format
 msgid "%d line"
 msgid_plural "%d lines"
 msgstr[0] "%d satır"
 msgstr[1] "%d satır"
 
-#: src/lib/ui/components/contentInfo.ts:177
+#: src/lib/ui/components/contentInfo.ts:186
 msgid "Missing File"
 msgstr "Eksik Dosya"
 
-#: src/lib/ui/components/contentInfo.ts:189
+#: src/lib/ui/components/contentInfo.ts:198
 msgid "Error"
 msgstr "Hata"
 

--- a/resources/po/zh_CN.po
+++ b/resources/po/zh_CN.po
@@ -8,11 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-<<<<<<< Updated upstream
-"POT-Creation-Date: 2026-04-26 12:23-0500\n"
-=======
-"POT-Creation-Date: 2026-07-09 00:11-0300\n"
->>>>>>> Stashed changes
+"POT-Creation-Date: 2026-07-09 00:47-0300\n"
 "PO-Revision-Date: 2025-12-19 18:30+0800\n"
 "Last-Translator: everyx <lunt.luo@gmail.com>\n"
 "Language-Team: Chinese (China)\n"
@@ -220,7 +216,7 @@ msgstr "选择哪些类型被允许"
 #: src/lib/preferences/dependencies/dependencies.ts:224
 #: src/lib/preferences/general/appExclusionSettings.ts:171
 #: src/lib/preferences/shortcuts/shortcutRow.ts:131
-#: src/lib/ui/components/editDialog.ts:314 src/lib/ui/indicator.ts:47
+#: src/lib/ui/components/editDialog.ts:315 src/lib/ui/indicator.ts:47
 msgid "Cancel"
 msgstr "取消"
 
@@ -348,7 +344,7 @@ msgid "Edit Action"
 msgstr "编辑动作"
 
 #: src/lib/preferences/actions/actionDialog.ts:662
-#: src/lib/ui/components/editDialog.ts:321
+#: src/lib/ui/components/editDialog.ts:322
 msgid "Save"
 msgstr "保存"
 
@@ -1801,45 +1797,6 @@ msgstr "剪贴板是空的"
 msgid "No Items Found"
 msgstr "未找到项目"
 
-<<<<<<< Updated upstream
-#: src/lib/ui/searchEntry.ts:150
-msgid "__All"
-msgstr "全部(_A)"
-
-#: src/lib/ui/searchEntry.ts:154
-msgid "__Text"
-msgstr "文本(_T)"
-
-#: src/lib/ui/searchEntry.ts:155
-msgid "__Code"
-msgstr "代码(_C)"
-
-#: src/lib/ui/searchEntry.ts:156
-msgid "__Image"
-msgstr "图片(_I)"
-
-#: src/lib/ui/searchEntry.ts:157
-msgid "__File"
-msgstr "文件(_F)"
-
-#: src/lib/ui/searchEntry.ts:158
-msgid "File__s"
-msgstr "文件(_S)"
-
-#: src/lib/ui/searchEntry.ts:159
-msgid "__Link"
-msgstr "链接(_L)"
-
-#: src/lib/ui/searchEntry.ts:160
-msgid "C__haracter"
-msgstr "字符(_H)"
-
-#: src/lib/ui/searchEntry.ts:161
-msgid "Colo__r"
-msgstr "颜色(_R)"
-
-#: src/lib/ui/searchEntry.ts:273
-=======
 #: src/lib/ui/searchEntry.ts:154
 msgid "__All"
 msgstr "全部(_A)"
@@ -1877,7 +1834,6 @@ msgid "Colo__r"
 msgstr "颜色(_R)"
 
 #: src/lib/ui/searchEntry.ts:277
->>>>>>> Stashed changes
 msgid "Type to search"
 msgstr "输入以搜索"
 

--- a/resources/po/zh_CN.po
+++ b/resources/po/zh_CN.po
@@ -8,7 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
+<<<<<<< Updated upstream
 "POT-Creation-Date: 2026-04-26 12:23-0500\n"
+=======
+"POT-Creation-Date: 2026-07-09 00:11-0300\n"
+>>>>>>> Stashed changes
 "PO-Revision-Date: 2025-12-19 18:30+0800\n"
 "Last-Translator: everyx <lunt.luo@gmail.com>\n"
 "Language-Team: Chinese (China)\n"
@@ -125,8 +129,8 @@ msgstr "已复制颜色"
 #: src/lib/preferences/general/feedbackSettings.ts:259
 #: src/lib/preferences/general/feedbackSettings.ts:308
 #: src/lib/preferences/shortcuts/itemShortcuts.ts:39
-#: src/lib/ui/components/editDialog.ts:217
-#: src/lib/ui/components/editDialog.ts:244
+#: src/lib/ui/components/editDialog.ts:225
+#: src/lib/ui/components/editDialog.ts:252
 msgid "None"
 msgstr "无"
 
@@ -155,7 +159,7 @@ msgstr "代码"
 #: src/lib/preferences/actions/actionDialog.ts:177
 #: src/lib/preferences/actions/actionDialog.ts:370
 #: src/lib/preferences/customization/items/fileItemCustomization.ts:79
-#: src/lib/ui/items/imageItem.ts:38
+#: src/lib/ui/items/imageItem.ts:37
 msgid "Image"
 msgstr "图片"
 
@@ -169,7 +173,7 @@ msgstr "文件"
 #: src/lib/preferences/actions/actionDefaults.ts:148
 #: src/lib/preferences/actions/actionDialog.ts:179
 #: src/lib/preferences/actions/actionDialog.ts:376
-#: src/lib/ui/items/filesItem.ts:140
+#: src/lib/ui/items/filesItem.ts:139
 msgid "Files"
 msgstr "多文件"
 
@@ -177,7 +181,7 @@ msgstr "多文件"
 #: src/lib/preferences/actions/actionDialog.ts:180
 #: src/lib/preferences/actions/actionDialog.ts:379
 #: src/lib/preferences/customization/items/linkItemCustomization.ts:45
-#: src/lib/ui/items/linkItem.ts:303
+#: src/lib/ui/items/linkItem.ts:304
 msgid "Link"
 msgstr "链接"
 
@@ -216,7 +220,7 @@ msgstr "选择哪些类型被允许"
 #: src/lib/preferences/dependencies/dependencies.ts:224
 #: src/lib/preferences/general/appExclusionSettings.ts:171
 #: src/lib/preferences/shortcuts/shortcutRow.ts:131
-#: src/lib/ui/components/editDialog.ts:306 src/lib/ui/indicator.ts:47
+#: src/lib/ui/components/editDialog.ts:314 src/lib/ui/indicator.ts:47
 msgid "Cancel"
 msgstr "取消"
 
@@ -344,7 +348,7 @@ msgid "Edit Action"
 msgstr "编辑动作"
 
 #: src/lib/preferences/actions/actionDialog.ts:662
-#: src/lib/ui/components/editDialog.ts:313
+#: src/lib/ui/components/editDialog.ts:321
 msgid "Save"
 msgstr "保存"
 
@@ -1465,7 +1469,7 @@ msgid ""
 msgstr "选择系统重启、注销或关机时对剪贴板历史记录的操作"
 
 #: src/lib/preferences/general/historySettings.ts:137
-#: src/lib/ui/clipboardDialog.ts:130 src/lib/ui/clipboardDialog.ts:235
+#: src/lib/ui/clipboardDialog.ts:134 src/lib/ui/clipboardDialog.ts:239
 #: src/lib/ui/indicator.ts:54
 msgid "Clear"
 msgstr "清除"
@@ -1473,6 +1477,10 @@ msgstr "清除"
 #: src/lib/preferences/general/historySettings.ts:137
 msgid "Keep All"
 msgstr "保留全部"
+
+#: src/lib/preferences/general/historySettings.ts:137
+msgid "Keep Pinned"
+msgstr ""
 
 #: src/lib/preferences/general/historySettings.ts:137
 msgid "Keep Pinned/Tagged"
@@ -1723,7 +1731,7 @@ msgstr "文件丢失"
 msgid "Error"
 msgstr "错误"
 
-#: src/lib/ui/components/editDialog.ts:269
+#: src/lib/ui/components/editDialog.ts:277
 msgid "Edit Clipboard Item"
 msgstr "编辑剪贴板项目"
 
@@ -1740,22 +1748,22 @@ msgid "Are you sure you want to clear your clipboard history?"
 msgstr "您确定要清除剪贴板历史记录吗？"
 
 #: src/lib/ui/indicator.ts:43
-msgid "Clear Pinned/Tagged Items"
-msgstr "清除已固定/已标记的项目"
+msgid "Clear Pinned Items"
+msgstr ""
 
-#: src/lib/ui/indicator.ts:102
+#: src/lib/ui/indicator.ts:99
 msgid "Incognito Mode"
 msgstr "隐私模式"
 
-#: src/lib/ui/indicator.ts:105
+#: src/lib/ui/indicator.ts:102
 msgid "Clear History"
 msgstr "清理历史"
 
-#: src/lib/ui/indicator.ts:106
+#: src/lib/ui/indicator.ts:103
 msgid "Settings"
 msgstr "设置"
 
-#: src/lib/ui/indicator.ts:199
+#: src/lib/ui/indicator.ts:196
 #, javascript-format
 msgid "%d File"
 msgid_plural "%d Files"
@@ -1765,13 +1773,13 @@ msgstr[0] "%d 个文件"
 msgid "Char"
 msgstr "字符"
 
-#: src/lib/ui/items/filesItem.ts:120
+#: src/lib/ui/items/filesItem.ts:119
 #, javascript-format
 msgid "%d more file"
 msgid_plural "%d more files"
 msgstr[0] "还有 %d 个文件"
 
-#: src/lib/ui/items/filesItem.ts:121
+#: src/lib/ui/items/filesItem.ts:120
 #, javascript-format
 msgid "%d file"
 msgid_plural "%d files"
@@ -1793,6 +1801,7 @@ msgstr "剪贴板是空的"
 msgid "No Items Found"
 msgstr "未找到项目"
 
+<<<<<<< Updated upstream
 #: src/lib/ui/searchEntry.ts:150
 msgid "__All"
 msgstr "全部(_A)"
@@ -1830,6 +1839,45 @@ msgid "Colo__r"
 msgstr "颜色(_R)"
 
 #: src/lib/ui/searchEntry.ts:273
+=======
+#: src/lib/ui/searchEntry.ts:154
+msgid "__All"
+msgstr "全部(_A)"
+
+#: src/lib/ui/searchEntry.ts:158
+msgid "__Text"
+msgstr "文本(_T)"
+
+#: src/lib/ui/searchEntry.ts:159
+msgid "__Code"
+msgstr "代码(_C)"
+
+#: src/lib/ui/searchEntry.ts:160
+msgid "__Image"
+msgstr "图片(_I)"
+
+#: src/lib/ui/searchEntry.ts:161
+msgid "__File"
+msgstr "文件(_F)"
+
+#: src/lib/ui/searchEntry.ts:162
+msgid "File__s"
+msgstr "文件(_S)"
+
+#: src/lib/ui/searchEntry.ts:163
+msgid "__Link"
+msgstr "链接(_L)"
+
+#: src/lib/ui/searchEntry.ts:164
+msgid "C__haracter"
+msgstr "字符(_H)"
+
+#: src/lib/ui/searchEntry.ts:165
+msgid "Colo__r"
+msgstr "颜色(_R)"
+
+#: src/lib/ui/searchEntry.ts:277
+>>>>>>> Stashed changes
 msgid "Type to search"
 msgstr "输入以搜索"
 

--- a/resources/po/zh_CN.po
+++ b/resources/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Copyous\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-09 00:47-0300\n"
+"POT-Creation-Date: 2026-08-16 16:01-0300\n"
 "PO-Revision-Date: 2025-12-19 18:30+0800\n"
 "Last-Translator: everyx <lunt.luo@gmail.com>\n"
 "Language-Team: Chinese (China)\n"
@@ -85,38 +85,38 @@ msgstr "禁用警告"
 msgid "Failed to load JSON"
 msgstr ""
 
-#: src/lib/misc/notifications.ts:63 src/lib/misc/notifications.ts:114
+#: src/lib/misc/notifications.ts:63 src/lib/misc/notifications.ts:125
 msgid "Copied Text"
 msgstr "已复制文本"
 
-#: src/lib/misc/notifications.ts:98 src/lib/misc/notifications.ts:123
+#: src/lib/misc/notifications.ts:109 src/lib/misc/notifications.ts:134
 msgid "Copied Image"
 msgstr "已复制图片"
 
-#: src/lib/misc/notifications.ts:99 src/lib/misc/notifications.ts:129
+#: src/lib/misc/notifications.ts:110 src/lib/misc/notifications.ts:140
 #, javascript-format
 msgid "Size: %d×%d px"
 msgstr "尺寸: %d×%d 像素"
 
-#: src/lib/misc/notifications.ts:118
+#: src/lib/misc/notifications.ts:129
 msgid "Copied Code"
 msgstr "已复制​​代码"
 
-#: src/lib/misc/notifications.ts:142
+#: src/lib/misc/notifications.ts:153
 #, javascript-format
 msgid "Copied %d File"
 msgid_plural "Copied %d Files"
 msgstr[0] "已复制 %d 个文件"
 
-#: src/lib/misc/notifications.ts:148
+#: src/lib/misc/notifications.ts:159
 msgid "Copied Link"
 msgstr "已复制链接"
 
-#: src/lib/misc/notifications.ts:152
+#: src/lib/misc/notifications.ts:163
 msgid "Copied Character"
 msgstr "已复制字符"
 
-#: src/lib/misc/notifications.ts:156
+#: src/lib/misc/notifications.ts:167
 msgid "Copied Color"
 msgstr "已复制颜色"
 
@@ -1686,44 +1686,44 @@ msgstr "禁用快捷键"
 msgid "Disabled"
 msgstr "已禁用"
 
-#: src/lib/ui/components/contentInfo.ts:32
+#: src/lib/ui/components/contentInfo.ts:35
 #, javascript-format
 msgid "%dh"
 msgstr "%d小时"
 
-#: src/lib/ui/components/contentInfo.ts:33
+#: src/lib/ui/components/contentInfo.ts:36
 #, javascript-format
 msgid "%dm"
 msgstr "%d分钟"
 
-#: src/lib/ui/components/contentInfo.ts:34
+#: src/lib/ui/components/contentInfo.ts:37
 #, javascript-format
 msgid "%ds"
 msgstr "%d秒"
 
-#: src/lib/ui/components/contentInfo.ts:106
+#: src/lib/ui/components/contentInfo.ts:116
 #, javascript-format
 msgid "%d char"
 msgid_plural "%d chars"
 msgstr[0] "%d 个字符"
 
-#: src/lib/ui/components/contentInfo.ts:114
+#: src/lib/ui/components/contentInfo.ts:123
 #, javascript-format
 msgid "%d word"
 msgid_plural "%d words"
 msgstr[0] "%d 个单词"
 
-#: src/lib/ui/components/contentInfo.ts:117
+#: src/lib/ui/components/contentInfo.ts:126
 #, javascript-format
 msgid "%d line"
 msgid_plural "%d lines"
 msgstr[0] "%d 行"
 
-#: src/lib/ui/components/contentInfo.ts:177
+#: src/lib/ui/components/contentInfo.ts:186
 msgid "Missing File"
 msgstr "文件丢失"
 
-#: src/lib/ui/components/contentInfo.ts:189
+#: src/lib/ui/components/contentInfo.ts:198
 msgid "Error"
 msgstr "错误"
 

--- a/resources/schemas/00-org.gnome.shell.extensions.copyous.enums.gschema.xml
+++ b/resources/schemas/00-org.gnome.shell.extensions.copyous.enums.gschema.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://gitlab.gnome.org/GNOME/glib/-/raw/HEAD/gio/gschema.dtd"?>
+<schemalist>
+	<enum id="org.gnome.shell.extensions.copyous.DatabaseBackend">
+		<value nick="default" value="0"/>
+		<value nick="memory" value="1"/>
+		<value nick="sqlite" value="2"/>
+		<value nick="json" value="3"/>
+	</enum>
+
+	<enum id="org.gnome.shell.extensions.copyous.ClipboardHistory">
+		<value nick="clear" value="0"/>
+		<value nick="keep-pinned-and-tagged" value="1"/>
+		<value nick="keep-all" value="2"/>
+		<value nick="keep-pinned" value="3"/>
+	</enum>
+
+	<enum id="org.gnome.shell.extensions.copyous.Orientation">
+		<value nick="horizontal" value="0"/>
+		<value nick="vertical" value="1"/>
+	</enum>
+
+	<enum id="org.gnome.shell.extensions.copyous.Position">
+		<value nick="top" value="0"/>
+		<!-- <value nick="left" value="0" /> -->
+		<value nick="center" value="1" />
+		<value nick="bottom" value="2"/>
+		<!-- <value nick="right" value="2" /> -->
+		<value nick="fill" value="3" />
+	</enum>
+
+	<enum id="org.gnome.shell.extensions.copyous.HeaderControlsVisibility">
+		<value nick="visible" value="0"/>
+		<value nick="visible-on-hover" value="1"/>
+		<value nick="hidden" value="2"/>
+	</enum>
+
+	<enum id="org.gnome.shell.extensions.copyous.Theme">
+		<value nick="default" value="0"/>
+		<value nick="yaru" value="1"/>
+		<value nick="custom" value="2"/>
+	</enum>
+
+	<enum id="org.gnome.shell.extensions.copyous.ColorScheme">
+		<value nick="system" value="0"/>
+		<value nick="dark" value="1"/>
+		<value nick="light" value="2"/>
+		<value nick="high-contrast" value="3"/>
+	</enum>
+
+	<enum id="org.gnome.shell.extensions.copyous.CustomColorScheme">
+		<value nick="dark" value="0"/>
+		<value nick="light" value="1"/>
+	</enum>
+
+	<enum id="org.gnome.shell.extensions.copyous.OpenClipboardDialogBehavior">
+		<value nick="toggle" value="0"/>
+		<value nick="open-or-select-next" value="1"/>
+	</enum>
+
+	<enum id="org.gnome.shell.extensions.copyous.MiddleClickAction">
+		<value nick="none" value="0"/>
+		<value nick="pin" value="1"/>
+		<value nick="delete" value="2"/>
+	</enum>
+
+	<enum id="org.gnome.shell.extensions.copyous.IndicatorDisplay">
+		<value nick="hidden" value="0"/>
+		<value nick="icon-only" value="1"/>
+		<value nick="clipboard-content-only" value="2"/>
+		<value nick="icon-and-clipboard-content" value="3"/>
+	</enum>
+
+	<enum id="org.gnome.shell.extensions.copyous.TextCountMode">
+		<value nick="characters" value="0"/>
+		<value nick="words" value="1"/>
+		<value nick="lines" value="2"/>
+	</enum>
+
+	<enum id="org.gnome.shell.extensions.copyous.BackgroundSize">
+		<value nick="cover" value="0" />
+		<value nick="contain" value="1" />
+	</enum>
+
+	<flags id="org.gnome.shell.extensions.copyous.file-item.FilePreviewType">
+		<value nick="text" value="1"/>
+		<value nick="image" value="2"/>
+		<value nick="thumbnail" value="4" />
+	</flags>
+
+	<enum id="org.gnome.shell.extensions.copyous.file-item.FilePreviewVisibility">
+		<value nick="file-preview" value="0"/>
+		<value nick="file-info" value="1"/>
+		<value nick="file-preview-or-file-info" value="2"/>
+		<value nick="file-preview-and-file-info" value="3"/>
+		<value nick="hidden" value="4"/>
+	</enum>
+</schemalist>

--- a/resources/schemas/org.gnome.shell.extensions.copyous.character-item.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.copyous.character-item.gschema.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://gitlab.gnome.org/GNOME/glib/-/raw/HEAD/gio/gschema.dtd"?>
+<schemalist>
+	<schema id="org.gnome.shell.extensions.copyous.character-item" path="/org/gnome/shell/extensions/copyous/character-item/">
+		<key name="max-characters" type="i">
+			<default>1</default>
+			<range min="1" max="4"/>
+			<summary>Maximum number of characters that are recognized as a character</summary>
+		</key>
+		<key name="show-unicode" type="b">
+			<default>false</default>
+			<summary>Show the Unicode of the character</summary>
+		</key>
+	</schema>
+</schemalist>

--- a/resources/schemas/org.gnome.shell.extensions.copyous.code-item.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.copyous.code-item.gschema.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://gitlab.gnome.org/GNOME/glib/-/raw/HEAD/gio/gschema.dtd"?>
+<schemalist>
+	<schema id="org.gnome.shell.extensions.copyous.code-item" path="/org/gnome/shell/extensions/copyous/code-item/">
+		<key name="syntax-highlighting" type="b">
+			<default>true</default>
+			<summary>Enable syntax highlighting</summary>
+		</key>
+		<key name="show-line-numbers" type="b">
+			<default>true</default>
+			<summary>Show line numbers</summary>
+		</key>
+		<key name="show-code-info" type="b">
+			<default>false</default>
+			<summary>Show extra information</summary>
+		</key>
+		<key name="text-count-mode" enum="org.gnome.shell.extensions.copyous.TextCountMode">
+			<default>'characters'</default>
+			<summary>Show the number of characters, words or lines</summary>
+		</key>
+	</schema>
+</schemalist>

--- a/resources/schemas/org.gnome.shell.extensions.copyous.file-item.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.copyous.file-item.gschema.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://gitlab.gnome.org/GNOME/glib/-/raw/HEAD/gio/gschema.dtd"?>
+<schemalist>
+	<schema id="org.gnome.shell.extensions.copyous.file-item" path="/org/gnome/shell/extensions/copyous/file-item/">
+		<key name="file-preview-visibility" enum="org.gnome.shell.extensions.copyous.file-item.FilePreviewVisibility">
+			<default>'file-preview-or-file-info'</default>
+			<summary>File preview shows a preview of the contents of a file. File info shows some information about the file.</summary>
+		</key>
+		<key name="file-preview-types" flags="org.gnome.shell.extensions.copyous.file-item.FilePreviewType">
+			<default>['text','image','thumbnail']</default>
+		</key>
+		<key name="file-preview-exclusion-patterns" type="as">
+			<default>[]</default>
+			<summary>Files matching these glob patterns will not have a preview</summary>
+		</key>
+		<key name="background-size" enum="org.gnome.shell.extensions.copyous.BackgroundSize">
+			<default>'cover'</default>
+			<summary>Background size of the image preview</summary>
+		</key>
+		<key name="syntax-highlighting" type="b">
+			<default>true</default>
+			<summary>Enable syntax highlighting in the text preview</summary>
+		</key>
+		<key name="show-line-numbers" type="b">
+			<default>true</default>
+			<summary>Show line numbers in the text preview</summary>
+		</key>
+	</schema>
+</schemalist>

--- a/resources/schemas/org.gnome.shell.extensions.copyous.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.copyous.gschema.xml
@@ -1,100 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://gitlab.gnome.org/GNOME/glib/-/raw/HEAD/gio/gschema.dtd"?>
 <schemalist>
-	<enum id="org.gnome.shell.extensions.copyous.DatabaseBackend">
-		<value nick="default" value="0"/>
-		<value nick="memory" value="1"/>
-		<value nick="sqlite" value="2"/>
-		<value nick="json" value="3"/>
-	</enum>
-
-	<enum id="org.gnome.shell.extensions.copyous.ClipboardHistory">
-		<value nick="clear" value="0"/>
-		<value nick="keep-pinned-and-tagged" value="1"/>
-		<value nick="keep-all" value="2"/>
-	</enum>
-
-	<enum id="org.gnome.shell.extensions.copyous.Orientation">
-		<value nick="horizontal" value="0"/>
-		<value nick="vertical" value="1"/>
-	</enum>
-
-	<enum id="org.gnome.shell.extensions.copyous.Position">
-		<value nick="top" value="0"/>
-		<!-- <value nick="left" value="0" /> -->
-		<value nick="center" value="1" />
-		<value nick="bottom" value="2"/>
-		<!-- <value nick="right" value="2" /> -->
-		<value nick="fill" value="3" />
-	</enum>
-
-	<enum id="org.gnome.shell.extensions.copyous.HeaderControlsVisibility">
-		<value nick="visible" value="0"/>
-		<value nick="visible-on-hover" value="1"/>
-		<value nick="hidden" value="2"/>
-	</enum>
-
-	<enum id="org.gnome.shell.extensions.copyous.Theme">
-		<value nick="default" value="0"/>
-		<value nick="yaru" value="1"/>
-		<value nick="custom" value="2"/>
-	</enum>
-
-	<enum id="org.gnome.shell.extensions.copyous.ColorScheme">
-		<value nick="system" value="0"/>
-		<value nick="dark" value="1"/>
-		<value nick="light" value="2"/>
-		<value nick="high-contrast" value="3"/>
-	</enum>
-
-	<enum id="org.gnome.shell.extensions.copyous.CustomColorScheme">
-		<value nick="dark" value="0"/>
-		<value nick="light" value="1"/>
-	</enum>
-
-	<enum id="org.gnome.shell.extensions.copyous.OpenClipboardDialogBehavior">
-		<value nick="toggle" value="0"/>
-		<value nick="open-or-select-next" value="1"/>
-	</enum>
-
-	<enum id="org.gnome.shell.extensions.copyous.MiddleClickAction">
-		<value nick="none" value="0"/>
-		<value nick="pin" value="1"/>
-		<value nick="delete" value="2"/>
-	</enum>
-
-	<enum id="org.gnome.shell.extensions.copyous.IndicatorDisplay">
-		<value nick="hidden" value="0"/>
-		<value nick="icon-only" value="1"/>
-		<value nick="clipboard-content-only" value="2"/>
-		<value nick="icon-and-clipboard-content" value="3"/>
-	</enum>
-
-	<enum id="org.gnome.shell.extensions.copyous.TextCountMode">
-		<value nick="characters" value="0"/>
-		<value nick="words" value="1"/>
-		<value nick="lines" value="2"/>
-	</enum>
-
-	<enum id="org.gnome.shell.extensions.copyous.BackgroundSize">
-		<value nick="cover" value="0" />
-		<value nick="contain" value="1" />
-	</enum>
-
-	<flags id="org.gnome.shell.extensions.copyous.file-item.FilePreviewType">
-		<value nick="text" value="1"/>
-		<value nick="image" value="2"/>
-		<value nick="thumbnail" value="4" />
-	</flags>
-
-	<enum id="org.gnome.shell.extensions.copyous.file-item.FilePreviewVisibility">
-		<value nick="file-preview" value="0"/>
-		<value nick="file-info" value="1"/>
-		<value nick="file-preview-or-file-info" value="2"/>
-		<value nick="file-preview-and-file-info" value="3"/>
-		<value nick="hidden" value="4"/>
-	</enum>
-
 	<schema id="org.gnome.shell.extensions.copyous" path="/org/gnome/shell/extensions/copyous/">
 		<!-- State -->
 		<key name="incognito" type="b">
@@ -124,18 +30,18 @@
 			<summary>Path to the database. When empty defaults to {XDG_DATA_HOME}/{EXTENSION UUID}/clipboard.{db,json} depending on the backend.</summary>
 		</key>
 		<key name="clipboard-history" enum="org.gnome.shell.extensions.copyous.ClipboardHistory">
-			<default>'keep-pinned-and-tagged'</default>
+			<default>'keep-pinned'</default>
 			<summary>Choose what to do with your clipboard history when you restart, log out, or shut down your system</summary>
 		</key>
 		<key name="history-length" type="i">
 			<default>50</default>
 			<range min="10" max="500"/>
-			<summary>Number of unpinned and untagged items to keep in the clipboard history</summary>
+			<summary>Number of unpinned items to keep in the clipboard history</summary>
 		</key>
 		<key name="history-time" type="i">
 			<default>0</default>
 			<range min="0" max="1440" />
-			<summary>Number of minutes to keep unpinned and untagged items in the clipboard history. Set to 0 to disable the time limit</summary>
+			<summary>Number of minutes to keep unpinned items in the clipboard history. Set to 0 to disable the time limit</summary>
 		</key>
 
 		<!-- Behavior -->
@@ -156,7 +62,7 @@
 			<summary>Prevents pinned clipboard items from being deleted</summary>
 		</key>
 		<key name="protect-tagged" type="b">
-			<default>true</default>
+			<default>false</default>
 			<summary>Prevents tagged clipboard items from being deleted</summary>
 		</key>
 		<key name="paste-on-copy" type="b">
@@ -383,136 +289,4 @@
 		</key>
 	</schema>
 
-	<schema id="org.gnome.shell.extensions.copyous.text-item" path="/org/gnome/shell/extensions/copyous/text-item/">
-		<key name="show-text-info" type="b">
-			<default>false</default>
-			<summary>Show extra information</summary>
-		</key>
-		<key name="text-count-mode" enum="org.gnome.shell.extensions.copyous.TextCountMode">
-			<default>'characters'</default>
-			<summary>Show the number of characters, words or lines</summary>
-		</key>
-	</schema>
-
-	<schema id="org.gnome.shell.extensions.copyous.code-item" path="/org/gnome/shell/extensions/copyous/code-item/">
-		<key name="syntax-highlighting" type="b">
-			<default>true</default>
-			<summary>Enable syntax highlighting</summary>
-		</key>
-		<key name="show-line-numbers" type="b">
-			<default>true</default>
-			<summary>Show line numbers</summary>
-		</key>
-		<key name="show-code-info" type="b">
-			<default>false</default>
-			<summary>Show extra information</summary>
-		</key>
-		<key name="text-count-mode" enum="org.gnome.shell.extensions.copyous.TextCountMode">
-			<default>'characters'</default>
-			<summary>Show the number of characters, words or lines</summary>
-		</key>
-	</schema>
-
-	<schema id="org.gnome.shell.extensions.copyous.image-item" path="/org/gnome/shell/extensions/copyous/image-item/">
-		<key name="show-image-info" type="b">
-			<default>false</default>
-			<summary>Show extra information</summary>
-		</key>
-		<key name="background-size" enum="org.gnome.shell.extensions.copyous.BackgroundSize">
-			<default>'cover'</default>
-			<summary>Background size of the image</summary>
-		</key>
-	</schema>
-
-	<schema id="org.gnome.shell.extensions.copyous.file-item" path="/org/gnome/shell/extensions/copyous/file-item/">
-		<key name="file-preview-visibility" enum="org.gnome.shell.extensions.copyous.file-item.FilePreviewVisibility">
-			<default>'file-preview-or-file-info'</default>
-			<summary>File preview shows a preview of the contents of a file. File info shows some information about the file.</summary>
-		</key>
-		<key name="file-preview-types" flags="org.gnome.shell.extensions.copyous.file-item.FilePreviewType">
-			<default>['text','image','thumbnail']</default>
-		</key>
-		<key name="file-preview-exclusion-patterns" type="as">
-			<default>[]</default>
-			<summary>Files matching these glob patterns will not have a preview</summary>
-		</key>
-		<key name="background-size" enum="org.gnome.shell.extensions.copyous.BackgroundSize">
-			<default>'cover'</default>
-			<summary>Background size of the image preview</summary>
-		</key>
-		<key name="syntax-highlighting" type="b">
-			<default>true</default>
-			<summary>Enable syntax highlighting in the text preview</summary>
-		</key>
-		<key name="show-line-numbers" type="b">
-			<default>true</default>
-			<summary>Show line numbers in the text preview</summary>
-		</key>
-	</schema>
-
-	<schema id="org.gnome.shell.extensions.copyous.link-item" path="/org/gnome/shell/extensions/copyous/link-item/">
-		<key name="show-link-preview" type="b">
-			<default>true</default>
-			<summary>Show a preview of the link</summary>
-		</key>
-		<key name="show-link-preview-image" type="b">
-			<default>true</default>
-			<summary>Show a preview image of the link</summary>
-		</key>
-		<key name="link-preview-image-background-size" enum="org.gnome.shell.extensions.copyous.BackgroundSize">
-			<default>'contain'</default>
-			<summary>Background size of the preview image of the link</summary>
-		</key>
-		<key name="link-preview-orientation" enum="org.gnome.shell.extensions.copyous.Orientation">
-			<default>'vertical'</default>
-			<summary>Orientation of the link preview</summary>
-		</key>
-		<key name="link-preview-exclusion-patterns" type="as">
-			<default>[]</default>
-			<summary>Links matching these regex patterns will not have a preview</summary>
-		</key>
-	</schema>
-
-	<schema id="org.gnome.shell.extensions.copyous.character-item" path="/org/gnome/shell/extensions/copyous/character-item/">
-		<key name="max-characters" type="i">
-			<default>1</default>
-			<range min="1" max="4"/>
-			<summary>Maximum number of characters that are recognized as a character</summary>
-		</key>
-		<key name="show-unicode" type="b">
-			<default>false</default>
-			<summary>Show the Unicode of the character</summary>
-		</key>
-	</schema>
-
-	<schema id="org.gnome.shell.extensions.copyous.theme" path="/org/gnome/shell/extensions/copyous/theme/">
-		<key name="theme" enum="org.gnome.shell.extensions.copyous.Theme">
-			<default>'default'</default>
-			<summary>The preferred theme</summary>
-		</key>
-		<key name="color-scheme" enum="org.gnome.shell.extensions.copyous.ColorScheme">
-			<default>'system'</default>
-			<summary>The color scheme of the theme</summary>
-		</key>
-		<key name="custom-color-scheme" enum="org.gnome.shell.extensions.copyous.CustomColorScheme">
-			<default>'dark'</default>
-			<summary>The color scheme of the custom theme</summary>
-		</key>
-		<key name="custom-bg-color" type="s">
-			<default>''</default>
-			<summary>The background color of the clipboard dialog</summary>
-		</key>
-		<key name="custom-fg-color" type="s">
-			<default>''</default>
-			<summary>The text color of the clipboard dialog</summary>
-		</key>
-		<key name="custom-card-bg-color" type="s">
-			<default>''</default>
-			<summary>The background color of clipboard items</summary>
-		</key>
-		<key name="custom-search-bg-color" type="s">
-			<default>''</default>
-			<summary>The background color of the search bar</summary>
-		</key>
-	</schema>
 </schemalist>

--- a/resources/schemas/org.gnome.shell.extensions.copyous.image-item.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.copyous.image-item.gschema.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://gitlab.gnome.org/GNOME/glib/-/raw/HEAD/gio/gschema.dtd"?>
+<schemalist>
+	<schema id="org.gnome.shell.extensions.copyous.image-item" path="/org/gnome/shell/extensions/copyous/image-item/">
+		<key name="show-image-info" type="b">
+			<default>false</default>
+			<summary>Show extra information</summary>
+		</key>
+		<key name="background-size" enum="org.gnome.shell.extensions.copyous.BackgroundSize">
+			<default>'cover'</default>
+			<summary>Background size of the image</summary>
+		</key>
+	</schema>
+</schemalist>

--- a/resources/schemas/org.gnome.shell.extensions.copyous.link-item.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.copyous.link-item.gschema.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://gitlab.gnome.org/GNOME/glib/-/raw/HEAD/gio/gschema.dtd"?>
+<schemalist>
+	<schema id="org.gnome.shell.extensions.copyous.link-item" path="/org/gnome/shell/extensions/copyous/link-item/">
+		<key name="show-link-preview" type="b">
+			<default>true</default>
+			<summary>Show a preview of the link</summary>
+		</key>
+		<key name="show-link-preview-image" type="b">
+			<default>true</default>
+			<summary>Show a preview image of the link</summary>
+		</key>
+		<key name="link-preview-image-background-size" enum="org.gnome.shell.extensions.copyous.BackgroundSize">
+			<default>'contain'</default>
+			<summary>Background size of the preview image of the link</summary>
+		</key>
+		<key name="link-preview-orientation" enum="org.gnome.shell.extensions.copyous.Orientation">
+			<default>'vertical'</default>
+			<summary>Orientation of the link preview</summary>
+		</key>
+		<key name="link-preview-exclusion-patterns" type="as">
+			<default>[]</default>
+			<summary>Links matching these regex patterns will not have a preview</summary>
+		</key>
+	</schema>
+</schemalist>

--- a/resources/schemas/org.gnome.shell.extensions.copyous.text-item.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.copyous.text-item.gschema.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://gitlab.gnome.org/GNOME/glib/-/raw/HEAD/gio/gschema.dtd"?>
+<schemalist>
+	<schema id="org.gnome.shell.extensions.copyous.text-item" path="/org/gnome/shell/extensions/copyous/text-item/">
+		<key name="show-text-info" type="b">
+			<default>false</default>
+			<summary>Show extra information</summary>
+		</key>
+		<key name="text-count-mode" enum="org.gnome.shell.extensions.copyous.TextCountMode">
+			<default>'characters'</default>
+			<summary>Show the number of characters, words or lines</summary>
+		</key>
+	</schema>
+</schemalist>

--- a/resources/schemas/org.gnome.shell.extensions.copyous.theme.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.copyous.theme.gschema.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://gitlab.gnome.org/GNOME/glib/-/raw/HEAD/gio/gschema.dtd"?>
+<schemalist>
+	<schema id="org.gnome.shell.extensions.copyous.theme" path="/org/gnome/shell/extensions/copyous/theme/">
+		<key name="theme" enum="org.gnome.shell.extensions.copyous.Theme">
+			<default>'default'</default>
+			<summary>The preferred theme</summary>
+		</key>
+		<key name="color-scheme" enum="org.gnome.shell.extensions.copyous.ColorScheme">
+			<default>'system'</default>
+			<summary>The color scheme of the theme</summary>
+		</key>
+		<key name="custom-color-scheme" enum="org.gnome.shell.extensions.copyous.CustomColorScheme">
+			<default>'dark'</default>
+			<summary>The color scheme of the custom theme</summary>
+		</key>
+		<key name="custom-bg-color" type="s">
+			<default>''</default>
+			<summary>The background color of the clipboard dialog</summary>
+		</key>
+		<key name="custom-fg-color" type="s">
+			<default>''</default>
+			<summary>The text color of the clipboard dialog</summary>
+		</key>
+		<key name="custom-card-bg-color" type="s">
+			<default>''</default>
+			<summary>The background color of clipboard items</summary>
+		</key>
+		<key name="custom-search-bg-color" type="s">
+			<default>''</default>
+			<summary>The background color of the search bar</summary>
+		</key>
+	</schema>
+</schemalist>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,23 +1,108 @@
 import GLib from 'gi://GLib';
-import Gio from 'gi://Gio';
+import type Gio from 'gi://Gio';
 
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import { ConsoleLike, Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 
-import type { HLJSApi } from 'highlight.js';
-import type { LanguageFn } from 'highlight.js';
+import type { HLJSApi, LanguageFn } from 'highlight.js';
 
-import { getDataPath, getHljsLanguages, getHljsPath } from './lib/common/constants.js';
-import { DbusService } from './lib/common/dbus.js';
-import { ClipboardHistory, CopyousSettings, migrateSettings } from './lib/common/settings.js';
-import { SoundManager, tryCreateSoundManager } from './lib/common/sound.js';
-import { ClipboardEntry } from './lib/database/database.js';
-import { ClipboardEntryTracker } from './lib/database/entryTracker.js';
-import { ClipboardManager } from './lib/misc/clipboard.js';
-import { NotificationManager } from './lib/misc/notifications.js';
-import { ShortcutManager } from './lib/misc/shortcuts.js';
-import { ThemeManager } from './lib/misc/theme.js';
-import { ClipboardDialog } from './lib/ui/clipboardDialog.js';
-import { ClipboardIndicator } from './lib/ui/indicator.js';
+import type { DbusService } from './lib/common/dbus.js';
+import type { ClipboardHistory, CopyousSettings } from './lib/common/settings.js';
+import type { SoundManager } from './lib/common/sound.js';
+import type { ClipboardEntry } from './lib/database/database.js';
+import type { ClipboardEntryTracker } from './lib/database/entryTracker.js';
+import type { ClipboardManager } from './lib/misc/clipboard.js';
+import type { NotificationManager } from './lib/misc/notifications.js';
+import type { ShortcutManager } from './lib/misc/shortcuts.js';
+import type { ThemeManager } from './lib/misc/theme.js';
+import type { ClipboardDialog } from './lib/ui/clipboardDialog.js';
+import type { ClipboardIndicator } from './lib/ui/indicator.js';
+
+// Top-level imports are intentionally minimal: only what is needed to schedule
+// the deferred enable.  All UI / DBus / database / theme code is dynamically
+// imported below, after `startup-complete`, so the extension does not block the
+// shell main loop on cold boot (which previously caused a brief vanilla-dock
+// flash and slowed the initial paint).
+
+type Mods = {
+	Gio: typeof import('gi://Gio').default;
+	getDataPath: typeof import('./lib/common/constants.js').getDataPath;
+	getHljsLanguages: typeof import('./lib/common/constants.js').getHljsLanguages;
+	getHljsPath: typeof import('./lib/common/constants.js').getHljsPath;
+	DbusService: typeof import('./lib/common/dbus.js').DbusService;
+	migrateSettings: typeof import('./lib/common/settings.js').migrateSettings;
+	tryCreateSoundManager: typeof import('./lib/common/sound.js').tryCreateSoundManager;
+	ClipboardEntryTracker: typeof import('./lib/database/entryTracker.js').ClipboardEntryTracker;
+	ClipboardManager: typeof import('./lib/misc/clipboard.js').ClipboardManager;
+	NotificationManager: typeof import('./lib/misc/notifications.js').NotificationManager;
+	ShortcutManager: typeof import('./lib/misc/shortcuts.js').ShortcutManager;
+	ThemeManager: typeof import('./lib/misc/theme.js').ThemeManager;
+	ClipboardDialog: typeof import('./lib/ui/clipboardDialog.js').ClipboardDialog;
+	ClipboardIndicator: typeof import('./lib/ui/indicator.js').ClipboardIndicator;
+};
+
+let M: Mods | null = null;
+
+const heavyDepsReady: Promise<void> = (async () => {
+	// Wait for the shell to finish its own startup before pulling in heavy
+	// dependencies. Importing big modules and constructing the dialog/indicator
+	// during shell startup competes with mutter for the main loop, which is
+	// what produced the dock flash on cold boot.
+	const lm = Main.layoutManager as { _startingUp?: boolean } & typeof Main.layoutManager;
+	if (lm._startingUp) {
+		await new Promise<void>((resolve) => {
+			const id = lm.connect('startup-complete', () => {
+				lm.disconnect(id);
+				resolve();
+			});
+		});
+	}
+
+	const [
+		gioMod,
+		constantsMod,
+		dbusMod,
+		settingsMod,
+		soundMod,
+		entryTrackerMod,
+		clipboardMod,
+		notificationsMod,
+		shortcutsMod,
+		themeMod,
+		clipboardDialogMod,
+		indicatorMod,
+	] = await Promise.all([
+		import('gi://Gio'),
+		import('./lib/common/constants.js'),
+		import('./lib/common/dbus.js'),
+		import('./lib/common/settings.js'),
+		import('./lib/common/sound.js'),
+		import('./lib/database/entryTracker.js'),
+		import('./lib/misc/clipboard.js'),
+		import('./lib/misc/notifications.js'),
+		import('./lib/misc/shortcuts.js'),
+		import('./lib/misc/theme.js'),
+		import('./lib/ui/clipboardDialog.js'),
+		import('./lib/ui/indicator.js'),
+	]);
+
+	M = {
+		Gio: gioMod.default,
+		getDataPath: constantsMod.getDataPath,
+		getHljsLanguages: constantsMod.getHljsLanguages,
+		getHljsPath: constantsMod.getHljsPath,
+		DbusService: dbusMod.DbusService,
+		migrateSettings: settingsMod.migrateSettings,
+		tryCreateSoundManager: soundMod.tryCreateSoundManager,
+		ClipboardEntryTracker: entryTrackerMod.ClipboardEntryTracker,
+		ClipboardManager: clipboardMod.ClipboardManager,
+		NotificationManager: notificationsMod.NotificationManager,
+		ShortcutManager: shortcutsMod.ShortcutManager,
+		ThemeManager: themeMod.ThemeManager,
+		ClipboardDialog: clipboardDialogMod.ClipboardDialog,
+		ClipboardIndicator: indicatorMod.ClipboardIndicator,
+	};
+})();
 
 export default class CopyousExtension extends Extension {
 	public settings!: CopyousSettings;
@@ -46,9 +131,29 @@ export default class CopyousExtension extends Extension {
 
 	public clipboardManager: ClipboardManager | undefined;
 
+	private _enableDeferredId: number = 0;
+	private _enabled: boolean = false;
+
 	override enable() {
+		this._enabled = true;
+
+		// Defer the actual work to an idle callback that resolves once the
+		// shell has finished startup and the heavy modules have loaded.
+		this._enableDeferredId = GLib.idle_add(GLib.PRIORITY_LOW, () => {
+			this._enableDeferredId = 0;
+			this._runDeferredEnable().catch((e: unknown) => {
+				console.error(`[Copyous] Failed to enable: ${e instanceof Error ? e.stack ?? e.message : String(e)}`);
+			});
+			return GLib.SOURCE_REMOVE;
+		});
+	}
+
+	private async _runDeferredEnable() {
+		await heavyDepsReady;
+		if (!this._enabled || !M) return;
+
 		this.settings = this.getSettings();
-		migrateSettings(this.settings);
+		M.migrateSettings(this.settings);
 
 		this.logger = this.getLogger();
 		const error = this.logger.error.bind(this.logger);
@@ -57,10 +162,10 @@ export default class CopyousExtension extends Extension {
 		this.initHljs().catch(error);
 
 		// Theme
-		this.themeManager = new ThemeManager(this);
+		this.themeManager = new M.ThemeManager(this);
 
 		// UI
-		this.clipboardDialog = new ClipboardDialog(this);
+		this.clipboardDialog = new M.ClipboardDialog(this);
 		this.clipboardDialog.connectObject(
 			'notify::opened',
 			async () => {
@@ -84,7 +189,7 @@ export default class CopyousExtension extends Extension {
 			this,
 		);
 
-		this.indicator = new ClipboardIndicator(this);
+		this.indicator = new M.ClipboardIndicator(this);
 		this.indicator.connectObject(
 			'open-dialog',
 			() => this.clipboardDialog?.open(),
@@ -94,7 +199,7 @@ export default class CopyousExtension extends Extension {
 		);
 
 		// DBus
-		this.dbus = new DbusService();
+		this.dbus = new M.DbusService();
 		this.dbus.connectObject(
 			'toggle',
 			() => this.clipboardDialog?.toggle(),
@@ -108,15 +213,15 @@ export default class CopyousExtension extends Extension {
 		);
 
 		// Feedback
-		this.notificationManager = new NotificationManager(this);
-		tryCreateSoundManager(this)
+		this.notificationManager = new M.NotificationManager(this);
+		M.tryCreateSoundManager(this)
 			.then((soundManager) => {
 				if (soundManager) this.soundManager = soundManager;
 			})
 			.catch(error);
 
 		// Shortcuts
-		this.shortcutsManager = new ShortcutManager(this, this.clipboardDialog);
+		this.shortcutsManager = new M.ShortcutManager(this, this.clipboardDialog);
 		this.shortcutsManager.connectObject(
 			'open-clipboard-dialog',
 			() => this.clipboardDialog?.dialogShortcut(),
@@ -126,7 +231,7 @@ export default class CopyousExtension extends Extension {
 		);
 
 		// Database
-		this.entryTracker = new ClipboardEntryTracker(this);
+		this.entryTracker = new M.ClipboardEntryTracker(this);
 		this.initEntryTracker().catch(error);
 		this.initHistoryTimeout().catch(error);
 
@@ -141,7 +246,7 @@ export default class CopyousExtension extends Extension {
 		);
 
 		// Clipboard Manager
-		this.clipboardManager = new ClipboardManager(this, this.entryTracker);
+		this.clipboardManager = new M.ClipboardManager(this, this.entryTracker);
 		this.clipboardManager.connectObject(
 			'clipboard',
 			(_: unknown, entry: ClipboardEntry) => {
@@ -170,9 +275,9 @@ export default class CopyousExtension extends Extension {
 	}
 
 	private async initHljs() {
-		if (this.hljs) return;
+		if (this.hljs || !M) return;
 
-		const hljsPath = getHljsPath(this);
+		const hljsPath = M.getHljsPath(this);
 		try {
 			const hljs = (await import(hljsPath.get_uri())) as { default: HLJSApi };
 			this.hljs = hljs.default;
@@ -192,11 +297,11 @@ export default class CopyousExtension extends Extension {
 
 			// Automatically load highlight.js
 			if (!this.hljsMonitor) {
-				this.hljsMonitor = hljsPath.monitor(Gio.FileMonitorFlags.NONE, null);
+				this.hljsMonitor = hljsPath.monitor(M.Gio.FileMonitorFlags.NONE, null);
 				this.hljsMonitor.connectObject(
 					'changed',
 					async (_monitor: unknown, _file: unknown, _otherFile: unknown, eventType: Gio.FileMonitorEvent) => {
-						if (eventType === Gio.FileMonitorEvent.CHANGES_DONE_HINT) {
+						if (eventType === M!.Gio.FileMonitorEvent.CHANGES_DONE_HINT) {
 							await this.initHljs();
 						}
 					},
@@ -207,17 +312,18 @@ export default class CopyousExtension extends Extension {
 	}
 
 	private async loadHljsLanguages() {
+		if (!M) return;
 		this.hljsLanguages ??= new Map<string, boolean>();
 
 		if (!this.hljsMonitor) {
-			const path = getDataPath(this).get_child('languages');
-			this.hljsMonitor = path.monitor_directory(Gio.FileMonitorFlags.NONE, null);
+			const path = M.getDataPath(this).get_child('languages');
+			this.hljsMonitor = path.monitor_directory(M.Gio.FileMonitorFlags.NONE, null);
 			this.hljsMonitor.connectObject(
 				'changed',
 				async (_monitor: unknown, _file: unknown, _otherFile: unknown, eventType: Gio.FileMonitorEvent) => {
 					if (
-						eventType === Gio.FileMonitorEvent.CHANGES_DONE_HINT ||
-						eventType === Gio.FileMonitorEvent.DELETED
+						eventType === M!.Gio.FileMonitorEvent.CHANGES_DONE_HINT ||
+						eventType === M!.Gio.FileMonitorEvent.DELETED
 					) {
 						await this.loadHljsLanguages();
 					}
@@ -226,7 +332,7 @@ export default class CopyousExtension extends Extension {
 			);
 		}
 
-		const languages = getHljsLanguages(this);
+		const languages = M.getHljsLanguages(this);
 		await Promise.all(
 			languages.map(async ([name, _language, _hash, path]) => {
 				const enabled = this.hljsLanguages?.get(name) ?? false;
@@ -264,9 +370,15 @@ export default class CopyousExtension extends Extension {
 
 		this.clipboardDialog?.clearEntries();
 		const entries = await this.entryTracker.init();
-		for (const entry of entries) {
-			this.clipboardDialog?.addEntry(entry);
-		}
+		this.clipboardDialog?.loadEntries(entries);
+
+		// Pre-warm allocation: ask for the preferred size at low priority so the
+		// first user-triggered open() does not pay the cost of laying out the
+		// scroll container from scratch.
+		GLib.idle_add(GLib.PRIORITY_LOW, () => {
+			this.clipboardDialog?.preWarm();
+			return GLib.SOURCE_REMOVE;
+		});
 	}
 
 	private async initHistoryTimeout() {
@@ -290,6 +402,14 @@ export default class CopyousExtension extends Extension {
 	}
 
 	override disable() {
+		this._enabled = false;
+
+		// Cancel deferred enable if it has not run yet
+		if (this._enableDeferredId) {
+			GLib.source_remove(this._enableDeferredId);
+			this._enableDeferredId = 0;
+		}
+
 		// UI
 		this.clipboardDialog?.disconnectObject(this);
 		this.clipboardDialog?.destroy();
@@ -326,8 +446,8 @@ export default class CopyousExtension extends Extension {
 		this.shortcutsManager = undefined;
 
 		// Database
-		const error = this.logger.error.bind(this.logger);
-		this.entryTracker?.destroy().catch(error);
+		const error = this.logger?.error.bind(this.logger);
+		this.entryTracker?.destroy().catch(error ?? (() => {}));
 		this.entryTracker = undefined;
 
 		if (this.historyTimeoutId >= 0) GLib.source_remove(this.historyTimeoutId);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -132,6 +132,8 @@ export default class CopyousExtension extends Extension {
 	public clipboardManager: ClipboardManager | undefined;
 
 	private _enableDeferredId: number = 0;
+	private _preWarmIdleId: number = 0;
+	private _entryTrackerInitSerial: number = 0;
 	private _enabled: boolean = false;
 
 	override enable() {
@@ -368,17 +370,30 @@ export default class CopyousExtension extends Extension {
 	private async initEntryTracker() {
 		if (!this.entryTracker || !this.entryTracker.shouldInit) return;
 
+		const serial = ++this._entryTrackerInitSerial;
+		this.cancelPreWarm();
+
 		this.clipboardDialog?.clearEntries();
 		const entries = await this.entryTracker.init();
+		if (!this._enabled || serial !== this._entryTrackerInitSerial) return;
+
 		this.clipboardDialog?.loadEntries(entries);
 
 		// Pre-warm allocation: ask for the preferred size at low priority so the
 		// first user-triggered open() does not pay the cost of laying out the
 		// scroll container from scratch.
-		GLib.idle_add(GLib.PRIORITY_LOW, () => {
+		this._preWarmIdleId = GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+			this._preWarmIdleId = 0;
 			this.clipboardDialog?.preWarm();
 			return GLib.SOURCE_REMOVE;
 		});
+	}
+
+	private cancelPreWarm() {
+		if (this._preWarmIdleId) {
+			GLib.source_remove(this._preWarmIdleId);
+			this._preWarmIdleId = 0;
+		}
 	}
 
 	private async initHistoryTimeout() {
@@ -403,6 +418,8 @@ export default class CopyousExtension extends Extension {
 
 	override disable() {
 		this._enabled = false;
+		this._entryTrackerInitSerial++;
+		this.cancelPreWarm();
 
 		// Cancel deferred enable if it has not run yet
 		if (this._enableDeferredId) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,8 @@
 import GLib from 'gi://GLib';
 import type Gio from 'gi://Gio';
 
-import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import { ConsoleLike, Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 import type { HLJSApi, LanguageFn } from 'highlight.js';
 
@@ -144,7 +144,7 @@ export default class CopyousExtension extends Extension {
 		this._enableDeferredId = GLib.idle_add(GLib.PRIORITY_LOW, () => {
 			this._enableDeferredId = 0;
 			this._runDeferredEnable().catch((e: unknown) => {
-				console.error(`[Copyous] Failed to enable: ${e instanceof Error ? e.stack ?? e.message : String(e)}`);
+				console.error(`[Copyous] Failed to enable: ${e instanceof Error ? (e.stack ?? e.message) : String(e)}`);
 			});
 			return GLib.SOURCE_REMOVE;
 		});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -280,6 +280,12 @@ export default class CopyousExtension extends Extension {
 		if (this.hljs || !M) return;
 
 		const hljsPath = M.getHljsPath(this);
+		if (!hljsPath.query_exists(null)) {
+			this.hljs = null;
+			this.monitorHljs(hljsPath);
+			return;
+		}
+
 		try {
 			const hljs = (await import(hljsPath.get_uri())) as { default: HLJSApi };
 			this.hljs = hljs.default;
@@ -296,20 +302,33 @@ export default class CopyousExtension extends Extension {
 			this.hljsCallbacks = undefined;
 		} catch {
 			this.hljs = null;
+			this.monitorHljs(hljsPath);
+		}
+	}
 
-			// Automatically load highlight.js
-			if (!this.hljsMonitor) {
-				this.hljsMonitor = hljsPath.monitor(M.Gio.FileMonitorFlags.NONE, null);
-				this.hljsMonitor.connectObject(
-					'changed',
-					async (_monitor: unknown, _file: unknown, _otherFile: unknown, eventType: Gio.FileMonitorEvent) => {
-						if (eventType === M!.Gio.FileMonitorEvent.CHANGES_DONE_HINT) {
-							await this.initHljs();
-						}
-					},
-					this,
-				);
-			}
+	private monitorHljs(hljsPath: Gio.File) {
+		if (this.hljsMonitor || !M) return;
+
+		try {
+			const parent = hljsPath.get_parent();
+			if (parent && !parent.query_exists(null)) parent.make_directory_with_parents(null);
+
+			this.hljsMonitor = hljsPath.monitor(M.Gio.FileMonitorFlags.NONE, null);
+			this.hljsMonitor.connectObject(
+				'changed',
+				async (_monitor: unknown, _file: unknown, _otherFile: unknown, eventType: Gio.FileMonitorEvent) => {
+					if (
+						eventType === M!.Gio.FileMonitorEvent.CHANGES_DONE_HINT ||
+						eventType === M!.Gio.FileMonitorEvent.CREATED ||
+						eventType === M!.Gio.FileMonitorEvent.MOVED_IN
+					) {
+						await this.initHljs();
+					}
+				},
+				this,
+			);
+		} catch (error) {
+			this.logger.warn(`Failed to monitor Highlight.js: ${String(error)}`);
 		}
 	}
 
@@ -319,6 +338,7 @@ export default class CopyousExtension extends Extension {
 
 		if (!this.hljsMonitor) {
 			const path = M.getDataPath(this).get_child('languages');
+			if (!path.query_exists(null)) path.make_directory_with_parents(null);
 			this.hljsMonitor = path.monitor_directory(M.Gio.FileMonitorFlags.NONE, null);
 			this.hljsMonitor.connectObject(
 				'changed',

--- a/src/lib/common/dbus.ts
+++ b/src/lib/common/dbus.ts
@@ -70,7 +70,7 @@ export class DbusService extends GObject.Object implements DBusInterface {
 	}
 
 	public ClearHistory(all: boolean) {
-		const history = all ? ClipboardHistory.Clear : ClipboardHistory.KeepPinnedAndTagged;
+		const history = all ? ClipboardHistory.Clear : ClipboardHistory.KeepPinned;
 		this.emit('clear-history', history);
 	}
 

--- a/src/lib/common/settings.ts
+++ b/src/lib/common/settings.ts
@@ -264,6 +264,7 @@ export const ClipboardHistory = {
 	Clear: 0,
 	KeepPinnedAndTagged: 1,
 	KeepAll: 2,
+	KeepPinned: 3,
 } as const;
 
 export type ClipboardHistory = (typeof ClipboardHistory)[keyof typeof ClipboardHistory];

--- a/src/lib/database/database.ts
+++ b/src/lib/database/database.ts
@@ -169,7 +169,8 @@ export interface Database {
 	 * Delete the oldest entries of the database.
 	 * @param offset The number of entries to keep.
 	 * @param olderThanMinutes Items older than this value will be deleted.
+	 * @param protectTagged Whether tagged items should be kept.
 	 * @returns The ids of entries that were deleted.
 	 */
-	deleteOldest(offset: number, olderThanMinutes: number): Promise<number[]>;
+	deleteOldest(offset: number, olderThanMinutes: number, protectTagged: boolean): Promise<number[]>;
 }

--- a/src/lib/database/database.ts
+++ b/src/lib/database/database.ts
@@ -8,7 +8,7 @@ import { ClipboardHistory } from '../common/settings.js';
 /**
  * Metadata.
  */
-export type Metadata = CodeMetadata | FileMetadata | LinkMetadata;
+export type Metadata = CodeMetadata | FileMetadata | ImageMetadata | LinkMetadata;
 
 /**
  * Programming language.
@@ -40,6 +40,14 @@ export type FileOperation = (typeof FileOperation)[keyof typeof FileOperation];
  */
 export interface FileMetadata {
 	operation: FileOperation;
+}
+
+/**
+ * Image dimensions.
+ */
+export interface ImageMetadata {
+	width: number;
+	height: number;
 }
 
 /**

--- a/src/lib/database/entryTracker.ts
+++ b/src/lib/database/entryTracker.ts
@@ -29,7 +29,7 @@ export class ClipboardEntryTracker {
 
 	async init(): Promise<ClipboardEntry[]> {
 		if (this._database) {
-			await this.clear();
+			// Reinitializing the backend must never apply the history cleanup policy.
 			await this.destroy();
 		}
 
@@ -186,6 +186,7 @@ export class ClipboardEntryTracker {
 	public async destroy() {
 		await this._database?.close();
 		this._database = undefined;
+		this._entries.clear();
 	}
 
 	/**
@@ -228,7 +229,7 @@ export class ClipboardEntryTracker {
 
 		const now = GLib.DateTime.new_now_utc();
 		const olderThan = now.add_minutes(-M)!;
-		const protectTagged = this.ext.settings.get_enum('clipboard-history') === ClipboardHistory.KeepPinnedAndTagged;
+		const protectTagged = this.shouldProtectTagged();
 
 		for (const entry of this._entries.values()) {
 			if (entry.pinned || (protectTagged && entry.tag)) continue;
@@ -241,9 +242,14 @@ export class ClipboardEntryTracker {
 	public async deleteOldest() {
 		const N = this.ext.settings.get_int('history-length');
 		const M = this.ext.settings.get_int('history-time');
-		const protectTagged = this.ext.settings.get_enum('clipboard-history') === ClipboardHistory.KeepPinnedAndTagged;
+		const protectTagged = this.shouldProtectTagged();
 		const deleted = await this._database?.deleteOldest(N, M, protectTagged);
 		if (deleted) deleted.forEach((id) => this.deleteFromDatabase(id));
+	}
+
+	private shouldProtectTagged(): boolean {
+		const history = this.ext.settings.get_enum('clipboard-history');
+		return history === ClipboardHistory.KeepPinnedAndTagged;
 	}
 
 	private track(...entries: ClipboardEntry[]) {

--- a/src/lib/database/entryTracker.ts
+++ b/src/lib/database/entryTracker.ts
@@ -228,9 +228,10 @@ export class ClipboardEntryTracker {
 
 		const now = GLib.DateTime.new_now_utc();
 		const olderThan = now.add_minutes(-M)!;
+		const protectTagged = this.ext.settings.get_enum('clipboard-history') === ClipboardHistory.KeepPinnedAndTagged;
 
 		for (const entry of this._entries.values()) {
-			if (entry.pinned || entry.tag) continue;
+			if (entry.pinned || (protectTagged && entry.tag)) continue;
 			if (entry.datetime.compare(olderThan) < 0) return true;
 		}
 
@@ -240,7 +241,8 @@ export class ClipboardEntryTracker {
 	public async deleteOldest() {
 		const N = this.ext.settings.get_int('history-length');
 		const M = this.ext.settings.get_int('history-time');
-		const deleted = await this._database?.deleteOldest(N, M);
+		const protectTagged = this.ext.settings.get_enum('clipboard-history') === ClipboardHistory.KeepPinnedAndTagged;
+		const deleted = await this._database?.deleteOldest(N, M, protectTagged);
 		if (deleted) deleted.forEach((id) => this.deleteFromDatabase(id));
 	}
 

--- a/src/lib/database/gda.ts
+++ b/src/lib/database/gda.ts
@@ -356,8 +356,10 @@ export class GdaDatabase implements Database {
 				return [];
 			}
 
-			// SELECT id FROM table (WHERE NOT (pinned == true OR tag IS NOT NULL))?
-			const [selectBuilder, where] = this.selectToDeleteBuilder(history === ClipboardHistory.KeepPinnedAndTagged);
+			const keepSaved =
+				history === ClipboardHistory.KeepPinned || history === ClipboardHistory.KeepPinnedAndTagged;
+			const protectTagged = history === ClipboardHistory.KeepPinnedAndTagged;
+			const [selectBuilder, where] = this.selectToDeleteBuilder(keepSaved, 0, protectTagged);
 
 			const selectStmt = selectBuilder.get_statement();
 			const datamodel = await async_statement_execute_select<ClipboardEntry>(
@@ -642,7 +644,7 @@ export class GdaDatabase implements Database {
 		return false;
 	}
 
-	public async deleteOldest(offset: number, olderThanMinutes: number): Promise<number[]> {
+	public async deleteOldest(offset: number, olderThanMinutes: number, protectTagged: boolean): Promise<number[]> {
 		try {
 			// WITH select1 AS (...) (SELECT id FROM select1) UNION (select2)
 			const selectBuilder = new this._Gda.SqlBuilder({
@@ -651,7 +653,7 @@ export class GdaDatabase implements Database {
 			selectBuilder.compound_set_type(this._Gda.SqlStatementCompoundType.UNION);
 
 			// SELECT id FROM table WHERE NOT (pinned == true OR tag IS NOT NULL) ORDER BY datetime LIMIT -1 OFFSET offset
-			const [select1Builder] = this.selectToDeleteBuilder();
+			const [select1Builder] = this.selectToDeleteBuilder(true, 0, protectTagged);
 			select1Builder.select_order_by(select1Builder.add_id('datetime'), false, null);
 			select1Builder.select_set_limit(add_expr_value(select1Builder, -1), add_expr_value(select1Builder, offset));
 
@@ -664,7 +666,7 @@ export class GdaDatabase implements Database {
 				workAroundBuilder.select_add_target('select1', null);
 				selectBuilder.compound_add_sub_select_from_builder(workAroundBuilder);
 
-				const [select2Builder] = this.selectToDeleteBuilder(true, olderThanMinutes);
+				const [select2Builder] = this.selectToDeleteBuilder(true, olderThanMinutes, protectTagged);
 				selectBuilder.compound_add_sub_select_from_builder(select2Builder as Gda.SqlBuilder);
 
 				// SELECT id FROM (SELECT id FROM table WHERE ...)
@@ -715,6 +717,7 @@ export class GdaDatabase implements Database {
 	private selectToDeleteBuilder(
 		includeWhere: boolean = true,
 		olderThanMinutes: number = 0,
+		protectTagged: boolean = true,
 	): [SqlBuilder<ClipboardEntry>, Gda.SqlBuilderId | null] {
 		// SELECT id FROM table (WHERE NOT (pinned == true OR tag IS NOT NULL) (AND datetime < DATETIME('now', '-n minutes'))?)?
 		const builder = new this._Gda.SqlBuilder({
@@ -725,23 +728,22 @@ export class GdaDatabase implements Database {
 
 		let where = null;
 		if (includeWhere) {
-			// WHERE NOT (pinned == true OR tag IS NOT NULL)
-			where = builder.add_cond(
-				this._Gda.SqlOperatorType.NOT,
-				builder.add_cond(
-					this._Gda.SqlOperatorType.OR,
-					builder.add_cond(
-						this._Gda.SqlOperatorType.EQ,
-						builder.add_id('pinned'),
-						add_expr_value(builder, true),
-						0,
-					),
-					builder.add_cond(this._Gda.SqlOperatorType.ISNOTNULL, builder.add_id('tag'), 0, 0),
-					0,
-				),
-				0,
+			const pinnedCondition = builder.add_cond(
+				this._Gda.SqlOperatorType.EQ,
+				builder.add_id('pinned'),
+				add_expr_value(builder, true),
 				0,
 			);
+			const protectedCondition = protectTagged
+				? builder.add_cond(
+						this._Gda.SqlOperatorType.OR,
+						pinnedCondition,
+						builder.add_cond(this._Gda.SqlOperatorType.ISNOTNULL, builder.add_id('tag'), 0, 0),
+						0,
+					)
+				: pinnedCondition;
+
+			where = builder.add_cond(this._Gda.SqlOperatorType.NOT, protectedCondition, 0, 0);
 
 			// AND datetime < DATETIME('now', '-n minutes')
 			if (olderThanMinutes > 0) {

--- a/src/lib/database/json.ts
+++ b/src/lib/database/json.ts
@@ -105,8 +105,12 @@ export class JsonDatabase extends MemoryDatabase {
 		return deleted;
 	}
 
-	public override async deleteOldest(offset: number, olderThanMinutes: number): Promise<number[]> {
-		const deleted = await super.deleteOldest(offset, olderThanMinutes);
+	public override async deleteOldest(
+		offset: number,
+		olderThanMinutes: number,
+		protectTagged: boolean,
+	): Promise<number[]> {
+		const deleted = await super.deleteOldest(offset, olderThanMinutes, protectTagged);
 		if (deleted.length > 0) this.save();
 		return deleted;
 	}

--- a/src/lib/database/memory.ts
+++ b/src/lib/database/memory.ts
@@ -120,27 +120,19 @@ export class MemoryDatabase implements Database {
 
 	public async deleteOldest(offset: number, olderThanMinutes: number, protectTagged: boolean): Promise<number[]> {
 		const entries = await this.entries();
-<<<<<<< Updated upstream
-		let deleted = entries
-			.filter((e) => !(e.pinned || e.tag))
-			.map((e) => e.id)
-			.slice(offset);
-=======
 		const unprotected = entries.filter((e) => !e.pinned && !(protectTagged && e.tag));
 		const deleted = unprotected.slice(offset).map((e) => e.id);
->>>>>>> Stashed changes
 
 		if (olderThanMinutes > 0) {
 			const now = GLib.DateTime.new_now_utc();
 			const olderThan = now.add_minutes(-olderThanMinutes)!;
-			deleted = [
-				...new Set([
-					...deleted,
-					...entries
-						.filter((e) => !(e.pinned || e.tag) && e.datetime.compare(olderThan) < 0)
-						.map((e) => e.id),
-				]),
-			];
+			const deletedIds = new Set(deleted);
+			for (const entry of unprotected) {
+				if (!deletedIds.has(entry.id) && entry.datetime.compare(olderThan) < 0) {
+					deletedIds.add(entry.id);
+					deleted.push(entry.id);
+				}
+			}
 		}
 
 		for (const id of deleted) {

--- a/src/lib/database/memory.ts
+++ b/src/lib/database/memory.ts
@@ -35,6 +35,16 @@ export class MemoryDatabase implements Database {
 					}
 				}
 				break;
+			case ClipboardHistory.KeepPinned:
+				deleted = [];
+				for (const [key, entry] of this._entries) {
+					if (!entry.pinned) {
+						this._entries.delete(key);
+						this._keys.delete(entry.id);
+						deleted.push(entry.id);
+					}
+				}
+				break;
 			case ClipboardHistory.KeepAll:
 				break;
 		}
@@ -108,12 +118,17 @@ export class MemoryDatabase implements Database {
 		return Promise.resolve(false);
 	}
 
-	public async deleteOldest(offset: number, olderThanMinutes: number): Promise<number[]> {
+	public async deleteOldest(offset: number, olderThanMinutes: number, protectTagged: boolean): Promise<number[]> {
 		const entries = await this.entries();
+<<<<<<< Updated upstream
 		let deleted = entries
 			.filter((e) => !(e.pinned || e.tag))
 			.map((e) => e.id)
 			.slice(offset);
+=======
+		const unprotected = entries.filter((e) => !e.pinned && !(protectTagged && e.tag));
+		const deleted = unprotected.slice(offset).map((e) => e.id);
+>>>>>>> Stashed changes
 
 		if (olderThanMinutes > 0) {
 			const now = GLib.DateTime.new_now_utc();

--- a/src/lib/misc/clipboard.ts
+++ b/src/lib/misc/clipboard.ts
@@ -1,6 +1,7 @@
 import Clutter from 'gi://Clutter';
 import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
+import GdkPixbuf from 'gi://GdkPixbuf';
 import Gio from 'gi://Gio';
 import Meta from 'gi://Meta';
 import St from 'gi://St';
@@ -9,7 +10,7 @@ import type CopyousExtension from '../../extension.js';
 import { Color } from '../common/color.js';
 import { ItemType, getImagesPath } from '../common/constants.js';
 import { registerClass } from '../common/gjs.js';
-import { ClipboardEntry, FileOperation, Metadata } from '../database/database.js';
+import { ClipboardEntry, FileOperation, ImageMetadata, Metadata } from '../database/database.js';
 import { ClipboardEntryTracker } from '../database/entryTracker.js';
 import { Keyboard } from './keyboard.js';
 
@@ -17,6 +18,10 @@ Gio._promisify(Gio.File.prototype, 'load_contents_async');
 Gio._promisify(Gio.File.prototype, 'replace_contents_async');
 Gio._promisify(Gio.MemoryOutputStream.prototype, 'splice_async');
 Gio._promisify(Meta.SelectionSource.prototype, 'read_async');
+
+const Utf8Decoder = new TextDecoder();
+const Utf8Encoder = new TextEncoder();
+const GraphemeSegmenter = new Intl.Segmenter();
 
 const MimeTypes = {
 	Text: ['text/plain;charset=utf-8', 'UTF8_STRING', 'text/plain', 'STRING'],
@@ -49,6 +54,12 @@ function contentChecksum(content: ClipboardContent): string | null {
 			return GLib.compute_checksum_for_string(GLib.ChecksumType.MD5, s, s.length);
 		}
 	}
+}
+
+function hasMoreGraphemes(text: string, max: number): boolean {
+	const iterator = GraphemeSegmenter.segment(text)[Symbol.iterator]();
+	for (let i = 0; i < max; i++) iterator.next();
+	return iterator.next().value !== undefined;
 }
 
 @registerClass({
@@ -118,7 +129,7 @@ export class ClipboardManager extends GObject.Object {
 		// File
 		if (content.type === ContentType.File) {
 			const s = `${FileOperation.Copy}\n${content.paths.join('\n')}`;
-			const bytes = new TextEncoder().encode(s);
+			const bytes = Utf8Encoder.encode(s);
 			this.clipboard.set_content(St.ClipboardType.CLIPBOARD, MimeTypes.File[0], bytes);
 			return;
 		}
@@ -210,9 +221,8 @@ export class ClipboardManager extends GObject.Object {
 		}
 	}
 
-	private shouldSave(selectionSource: Meta.SelectionSource): boolean {
+	private shouldSave(mimeTypes: readonly string[]): boolean {
 		// Mime Type
-		const mimeTypes = selectionSource.get_mimetypes();
 		if (MimeTypes.Sensitive.some((value) => mimeTypes.includes(value))) {
 			return false;
 		}
@@ -236,7 +246,8 @@ export class ClipboardManager extends GObject.Object {
 			if (selectionSource === null) return;
 			if (selectionType !== Meta.SelectionType.SELECTION_CLIPBOARD) return;
 
-			const content = await this.getContent(selectionSource);
+			const mimeTypes = selectionSource.get_mimetypes();
+			const content = await this.getContent(selectionSource, mimeTypes);
 			if (!content) return;
 
 			const checksum = contentChecksum(content);
@@ -261,7 +272,7 @@ export class ClipboardManager extends GObject.Object {
 			// Check if history should be saved after setting the previous clipboard item.
 			// This ensures that content copied in incognito mode is not saved to history
 			// after copying an item after exiting incognito mode.
-			if (!this.shouldSave(selectionSource)) return;
+			if (!this.shouldSave(mimeTypes)) return;
 
 			const res = await this.convertContent(content);
 			if (!res) return;
@@ -276,7 +287,10 @@ export class ClipboardManager extends GObject.Object {
 		}
 	}
 
-	private async getContent(selectionSource: Meta.SelectionSource): Promise<ClipboardContent | null> {
+	private async getContent(
+		selectionSource: Meta.SelectionSource,
+		mimeTypes: readonly string[],
+	): Promise<ClipboardContent | null> {
 		async function getBytes(mimeType: string): Promise<Uint8Array<ArrayBufferLike>> {
 			const source = await selectionSource.read_async(mimeType, null);
 			const out = Gio.MemoryOutputStream.new_resizable();
@@ -288,8 +302,6 @@ export class ClipboardManager extends GObject.Object {
 			);
 			return out.steal_as_bytes().toArray();
 		}
-
-		const mimeTypes = selectionSource.get_mimetypes();
 
 		// Image
 		const imageMimeType = MimeTypes.Image.find((value) => mimeTypes.includes(value));
@@ -308,7 +320,7 @@ export class ClipboardManager extends GObject.Object {
 		const fileMimeType = MimeTypes.File.find((value) => mimeTypes.includes(value));
 		if (fileMimeType) {
 			const bytes = await getBytes(fileMimeType);
-			const text = new TextDecoder().decode(bytes).trim();
+			const text = Utf8Decoder.decode(bytes).trim();
 			if (text) {
 				const files = text
 					.split('\n')
@@ -329,7 +341,7 @@ export class ClipboardManager extends GObject.Object {
 		const textMimeType = MimeTypes.Text.find((value) => mimeTypes.includes(value));
 		if (textMimeType) {
 			const bytes = await getBytes(textMimeType);
-			const text = new TextDecoder().decode(bytes);
+			const text = Utf8Decoder.decode(bytes);
 			if (text && text.trim()) {
 				return { type: ContentType.Text, text };
 			} else {
@@ -354,10 +366,8 @@ export class ClipboardManager extends GObject.Object {
 			}
 
 			// Character
-			const iterator = new Intl.Segmenter().segment(trimmed)[Symbol.iterator]();
 			const maxCharacters = this.ext.settings.get_child('character-item').get_int('max-characters');
-			for (let i = 0; i < maxCharacters; i++) iterator.next();
-			if (!iterator.next().value) {
+			if (!hasMoreGraphemes(trimmed, maxCharacters)) {
 				return [ItemType.Character, content.text, null];
 			}
 
@@ -402,7 +412,15 @@ export class ClipboardManager extends GObject.Object {
 					);
 				}
 
-				return [ItemType.Image, image.get_uri(), null];
+				let metadata: ImageMetadata | null = null;
+				try {
+					const [, width, height] = GdkPixbuf.Pixbuf.get_file_info(image.get_path()!);
+					if (width > 0 && height > 0) metadata = { width, height };
+				} catch {
+					// Keep image without dimensions.
+				}
+
+				return [ItemType.Image, image.get_uri(), metadata];
 			} catch {
 				return null;
 			}

--- a/src/lib/misc/notifications.ts
+++ b/src/lib/misc/notifications.ts
@@ -69,13 +69,24 @@ export class NotificationManager extends GObject.Object {
 	}
 
 	private createImageContent(pixbuf: GdkPixbuf.Pixbuf): St.ImageContent {
+		// Cogl must not read RGB rows as RGBA. That can overrun the pixbuf
+		// buffer and crash GNOME Shell in native memcpy code.
+		const iconPixbuf = pixbuf.get_has_alpha() ? pixbuf : pixbuf.add_alpha(false, 0, 0, 0);
+		if (!iconPixbuf) throw new Error('Failed to convert notification image to RGBA');
 		const context = global.stage.context.get_backend().get_cogl_context();
-		const pixels = pixbuf.get_pixels();
+		const pixels = iconPixbuf.get_pixels();
 		const content = new St.ImageContent({
-			preferred_width: pixbuf.width,
-			preferred_height: pixbuf.height,
+			preferred_width: iconPixbuf.width,
+			preferred_height: iconPixbuf.height,
 		});
-		content.set_bytes(context, pixels, Cogl.PixelFormat.RGBA_8888, pixbuf.width, pixbuf.height, pixbuf.rowstride);
+		content.set_bytes(
+			context,
+			pixels,
+			Cogl.PixelFormat.RGBA_8888,
+			iconPixbuf.width,
+			iconPixbuf.height,
+			iconPixbuf.rowstride,
+		);
 		return content;
 	}
 

--- a/src/lib/preferences/general/historySettings.ts
+++ b/src/lib/preferences/general/historySettings.ts
@@ -134,7 +134,7 @@ export class HistorySettings extends Adw.PreferencesGroup {
 			subtitle: _(
 				'Choose what to do with your clipboard history when you restart, log out, or shut down your system',
 			),
-			model: Gtk.StringList.new([_('Clear'), _('Keep Pinned/Tagged'), _('Keep All')]),
+			model: Gtk.StringList.new([_('Clear'), _('Keep Pinned/Tagged'), _('Keep All'), _('Keep Pinned')]),
 			sensitive: false,
 		});
 		this.add(this._clipboardHistory);

--- a/src/lib/ui/clipboardDialog.ts
+++ b/src/lib/ui/clipboardDialog.ts
@@ -34,7 +34,7 @@ import { TextItem } from './items/textItem.js';
 import { CenterBox, CollapsibleHeaderLayout, FitConstraint } from './layout.js';
 import { SearchEntry, SearchQuery } from './searchEntry.js';
 
-const ANIMATION_TIME = 150;
+const ANIMATION_TIME = 100;
 
 @registerClass()
 class IncognitoButton extends St.Button {
@@ -260,6 +260,7 @@ export class ClipboardDialog extends St.Widget {
 	private _cursor: [number, number] | null = null;
 
 	private _orientation: Clutter.Orientation = Clutter.Orientation.HORIZONTAL;
+	private _layoutDirty: boolean = true;
 
 	private readonly _ibusManager: IBusManager.IBusManager;
 
@@ -378,22 +379,29 @@ export class ClipboardDialog extends St.Widget {
 		// Bind properties
 		// prettier-ignore
 		this.ext.settings.connectObject(
-			'changed::show-at-pointer', this.updatePosition.bind(this),
-			'changed::clipboard-orientation', this.updatePosition.bind(this),
-			'changed::clipboard-position-horizontal', this.updatePosition.bind(this),
-			'changed::clipboard-position-vertical', this.updatePosition.bind(this),
-			'changed::clipboard-size', this.updatePosition.bind(this),
-			'changed::clipboard-margin-top', this.updateMargins.bind(this),
-			'changed::clipboard-margin-bottom', this.updateMargins.bind(this),
-			'changed::clipboard-margin-left', this.updateMargins.bind(this),
-			'changed::clipboard-margin-right', this.updateMargins.bind(this),
+			'changed::show-at-pointer', this.markLayoutDirty.bind(this),
+			'changed::clipboard-orientation', this.markLayoutDirty.bind(this),
+			'changed::clipboard-position-horizontal', this.markLayoutDirty.bind(this),
+			'changed::clipboard-position-vertical', this.markLayoutDirty.bind(this),
+			'changed::clipboard-size', this.markLayoutDirty.bind(this),
+			'changed::clipboard-margin-top', this.markLayoutDirty.bind(this),
+			'changed::clipboard-margin-bottom', this.markLayoutDirty.bind(this),
+			'changed::clipboard-margin-left', this.markLayoutDirty.bind(this),
+			'changed::clipboard-margin-right', this.markLayoutDirty.bind(this),
 			this);
+	}
 
+	private markLayoutDirty() {
+		this._layoutDirty = true;
+		// If currently visible, apply immediately so user-driven setting changes are reflected.
+		if (this.opened) this.applyLayoutIfDirty();
+	}
+
+	private applyLayoutIfDirty() {
+		if (!this._layoutDirty) return;
+		this._layoutDirty = false;
 		this.updatePosition();
 		this.updateMargins();
-
-		// Update initial search for when exclude-pinned or exclude-tagged is enabled
-		this._scrollView.search(this._header.searchEntry.searchQuery);
 	}
 
 	override destroy() {
@@ -418,8 +426,20 @@ export class ClipboardDialog extends St.Widget {
 		else this.close();
 	}
 
+	public preWarm() {
+		// Force one layout pass while still hidden so first open() is snappier.
+		// Reading get_preferred_size triggers Clutter's allocation cycle, which
+		// caches style nodes and child measurements.
+		this.applyLayoutIfDirty();
+		this._dialog.get_preferred_size();
+	}
+
 	public open() {
 		if (this.opened) return;
+
+		// Lazy: layout settings are read on first open (and after any change)
+		// instead of in the constructor, keeping the deferred enable cheap.
+		this.applyLayoutIfDirty();
 
 		this._updateCursor = false;
 		this._nextCursor = this._cursor;
@@ -533,6 +553,24 @@ export class ClipboardDialog extends St.Widget {
 	}
 
 	public addEntry(entry: ClipboardEntry): void {
+		const item = this.createItem(entry);
+		if (!item) return;
+		this._scrollView.addItem(item);
+	}
+
+	public loadEntries(entries: ClipboardEntry[]): void {
+		const items = [];
+		for (const entry of entries) {
+			const item = this.createItem(entry);
+			if (item) items.push(item);
+		}
+		this._scrollView.loadItems(items);
+
+		// Apply initial search filter for exclude-pinned / exclude-tagged once after bulk load.
+		this._scrollView.search(this._header.searchEntry.searchQuery);
+	}
+
+	private createItem(entry: ClipboardEntry) {
 		let item;
 		try {
 			item = (() => {
@@ -560,11 +598,11 @@ export class ClipboardDialog extends St.Widget {
 
 			if (!item) {
 				this.ext.logger.error('Unknown item type', entry);
-				return;
+				return null;
 			}
 		} catch (e) {
 			this.ext.logger.error(e);
-			return;
+			return null;
 		}
 
 		// Connect edit
@@ -621,7 +659,7 @@ export class ClipboardDialog extends St.Widget {
 			this,
 		);
 
-		this._scrollView.addItem(item);
+		return item;
 	}
 
 	public dialogShortcut() {

--- a/src/lib/ui/clipboardDialog.ts
+++ b/src/lib/ui/clipboardDialog.ts
@@ -259,6 +259,7 @@ class ClipboardDialogFooter extends St.BoxLayout {
 export class ClipboardDialog extends St.Widget {
 	private _grab: Clutter.Grab | null = null;
 	private _open: boolean = false;
+	private _closing: boolean = false;
 	private _updateCursor: boolean = true;
 	private _nextCursor: [number, number] | null = null;
 	private _cursor: [number, number] | null = null;
@@ -451,6 +452,10 @@ export class ClipboardDialog extends St.Widget {
 
 	public open() {
 		if (this.opened) return;
+		if (this._closing) {
+			this._dialog.remove_all_transitions();
+			this.finishClose();
+		}
 
 		// Lazy: layout settings are read on first open (and after any change)
 		// instead of in the constructor, keeping the deferred enable cheap.
@@ -521,6 +526,7 @@ export class ClipboardDialog extends St.Widget {
 		if (!this.opened) return;
 
 		this.opened = false;
+		this._closing = true;
 		this._updateCursor = true;
 		this._clipboardItemMenu.close();
 
@@ -558,16 +564,7 @@ export class ClipboardDialog extends St.Widget {
 			...easeArgs,
 			duration: ANIMATION_TIME,
 			mode,
-<<<<<<< Updated upstream
-			onComplete: () => {
-				Main.popModal(this._grab);
-				this._grab = null;
-				this.hide();
-				global.compositor.enable_unredirect();
-			},
-=======
 			onComplete: () => this.finishClose(),
->>>>>>> Stashed changes
 		});
 	}
 

--- a/src/lib/ui/clipboardDialog.ts
+++ b/src/lib/ui/clipboardDialog.ts
@@ -1,4 +1,5 @@
 import Clutter from 'gi://Clutter';
+import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 import Gio from 'gi://Gio';
 import Graphene from 'gi://Graphene';
@@ -24,6 +25,7 @@ import { ClipboardScrollView } from './clipboardScrollView.js';
 import { ClipboardItemMenu } from './components/clipboardItemMenu.js';
 import { ConfirmClearHistoryDialog } from './indicator.js';
 import { CharacterItem } from './items/characterItem.js';
+import type { ClipboardItem } from './items/clipboardItem.js';
 import { CodeItem } from './items/codeItem.js';
 import { ColorItem } from './items/colorItem.js';
 import { FileItem } from './items/fileItem.js';
@@ -35,6 +37,8 @@ import { CenterBox, CollapsibleHeaderLayout, FitConstraint } from './layout.js';
 import { SearchEntry, SearchQuery } from './searchEntry.js';
 
 const ANIMATION_TIME = 100;
+const INITIAL_LOAD_ITEMS = 24;
+const LOAD_BATCH_ITEMS = 24;
 
 @registerClass()
 class IncognitoButton extends St.Button {
@@ -258,6 +262,8 @@ export class ClipboardDialog extends St.Widget {
 	private _updateCursor: boolean = true;
 	private _nextCursor: [number, number] | null = null;
 	private _cursor: [number, number] | null = null;
+	private _loadIdleId: number = 0;
+	private _loadGeneration: number = 0;
 
 	private _orientation: Clutter.Orientation = Clutter.Orientation.HORIZONTAL;
 	private _layoutDirty: boolean = true;
@@ -405,9 +411,15 @@ export class ClipboardDialog extends St.Widget {
 	}
 
 	override destroy() {
+		this.cancelPendingLoad();
 		(Main.inputMethod as Clutter.InputMethod).disconnectObject(this);
 		this._ibusManager.disconnectObject(this);
 		this.ext.settings.disconnectObject(this);
+
+		if (this._grab) {
+			this._dialog.remove_all_transitions();
+			this.finishClose();
+		}
 
 		super.destroy();
 	}
@@ -427,11 +439,14 @@ export class ClipboardDialog extends St.Widget {
 	}
 
 	public preWarm() {
+		if (this.opened || !this.get_parent()) return;
+
 		// Force one layout pass while still hidden so first open() is snappier.
 		// Reading get_preferred_size triggers Clutter's allocation cycle, which
 		// caches style nodes and child measurements.
 		this.applyLayoutIfDirty();
 		this._dialog.get_preferred_size();
+		this._scrollView.preWarm();
 	}
 
 	public open() {
@@ -543,13 +558,28 @@ export class ClipboardDialog extends St.Widget {
 			...easeArgs,
 			duration: ANIMATION_TIME,
 			mode,
+<<<<<<< Updated upstream
 			onComplete: () => {
 				Main.popModal(this._grab);
 				this._grab = null;
 				this.hide();
 				global.compositor.enable_unredirect();
 			},
+=======
+			onComplete: () => this.finishClose(),
+>>>>>>> Stashed changes
 		});
+	}
+
+	private finishClose() {
+		if (this._grab) {
+			Main.popModal(this._grab);
+			this._grab = null;
+		}
+
+		this._closing = false;
+		this.hide();
+		global.compositor.enable_unredirect();
 	}
 
 	public addEntry(entry: ClipboardEntry): void {
@@ -559,8 +589,12 @@ export class ClipboardDialog extends St.Widget {
 	}
 
 	public loadEntries(entries: ClipboardEntry[]): void {
+		this.cancelPendingLoad();
+		const generation = ++this._loadGeneration;
+		const initialEntries = entries.slice(0, INITIAL_LOAD_ITEMS);
+
 		const items = [];
-		for (const entry of entries) {
+		for (const entry of initialEntries) {
 			const item = this.createItem(entry);
 			if (item) items.push(item);
 		}
@@ -568,9 +602,39 @@ export class ClipboardDialog extends St.Widget {
 
 		// Apply initial search filter for exclude-pinned / exclude-tagged once after bulk load.
 		this._scrollView.search(this._header.searchEntry.searchQuery);
+
+		let index = initialEntries.length;
+		if (index >= entries.length) return;
+
+		this._loadIdleId = GLib.idle_add(GLib.PRIORITY_LOW, () => {
+			if (generation !== this._loadGeneration || !this.get_parent()) {
+				this._loadIdleId = 0;
+				return GLib.SOURCE_REMOVE;
+			}
+
+			const batch: ClipboardItem[] = [];
+			for (let end = Math.min(index + LOAD_BATCH_ITEMS, entries.length); index < end; index++) {
+				const item = this.createItem(entries[index]!);
+				if (item) batch.push(item);
+			}
+
+			this._scrollView.appendItems(batch);
+			if (index < entries.length) return GLib.SOURCE_CONTINUE;
+
+			this._loadIdleId = 0;
+			return GLib.SOURCE_REMOVE;
+		});
 	}
 
-	private createItem(entry: ClipboardEntry) {
+	private cancelPendingLoad() {
+		this._loadGeneration++;
+		if (this._loadIdleId) {
+			GLib.source_remove(this._loadIdleId);
+			this._loadIdleId = 0;
+		}
+	}
+
+	private createItem(entry: ClipboardEntry): ClipboardItem | null {
 		let item;
 		try {
 			item = (() => {
@@ -673,6 +737,7 @@ export class ClipboardDialog extends St.Widget {
 	}
 
 	public clearEntries() {
+		this.cancelPendingLoad();
 		this._scrollView.clearItems();
 	}
 

--- a/src/lib/ui/clipboardDialog.ts
+++ b/src/lib/ui/clipboardDialog.ts
@@ -37,8 +37,8 @@ import { CenterBox, CollapsibleHeaderLayout, FitConstraint } from './layout.js';
 import { SearchEntry, SearchQuery } from './searchEntry.js';
 
 const ANIMATION_TIME = 100;
-const INITIAL_LOAD_ITEMS = 24;
-const LOAD_BATCH_ITEMS = 24;
+const INITIAL_LOAD_ITEMS = 4;
+const LOAD_BATCH_ITEMS = 12;
 
 @registerClass()
 class IncognitoButton extends St.Button {
@@ -611,7 +611,7 @@ export class ClipboardDialog extends St.Widget {
 
 			const batch: ClipboardItem[] = [];
 			for (let end = Math.min(index + LOAD_BATCH_ITEMS, entries.length); index < end; index++) {
-				const item = this.createItem(entries[index]!);
+				const item = this.createItem(entries[index]!, false);
 				if (item) batch.push(item);
 			}
 
@@ -631,7 +631,7 @@ export class ClipboardDialog extends St.Widget {
 		}
 	}
 
-	private createItem(entry: ClipboardEntry): ClipboardItem | null {
+	private createItem(entry: ClipboardEntry, loadImagePreview: boolean = true): ClipboardItem | null {
 		let item;
 		try {
 			item = (() => {
@@ -641,7 +641,7 @@ export class ClipboardDialog extends St.Widget {
 					case ItemType.Code:
 						return new CodeItem(this.ext, entry);
 					case ItemType.Image:
-						return new ImageItem(this.ext, entry);
+						return new ImageItem(this.ext, entry, loadImagePreview);
 					case ItemType.File:
 						return new FileItem(this.ext, entry);
 					case ItemType.Files:

--- a/src/lib/ui/clipboardScrollContainer.ts
+++ b/src/lib/ui/clipboardScrollContainer.ts
@@ -124,6 +124,28 @@ export class ClipboardScrollContainer extends St.BoxLayout {
 			item.search(this._lastQuery);
 		}
 
+		this.connectItemSignals(item);
+	}
+
+	public loadItems(items: ClipboardItem[]): void {
+		if (items.length === 0) {
+			this.updateVisible();
+			return;
+		}
+
+		this.removePseudoclasses();
+		if (this._statusItem.get_parent() !== null) this.remove_child(this._statusItem);
+
+		for (const item of items) {
+			if (item.get_parent() === this) this.remove_child(item);
+			this.add_child(item);
+			this.connectItemSignals(item);
+		}
+
+		this.updateVisible();
+	}
+
+	private connectItemSignals(item: ClipboardItem): void {
 		// Move item when datetime changes
 		item.entry.connect('notify::datetime', () => this.insertOrMoveItem(item));
 

--- a/src/lib/ui/clipboardScrollContainer.ts
+++ b/src/lib/ui/clipboardScrollContainer.ts
@@ -6,7 +6,6 @@ import { registerClass } from '../common/gjs.js';
 import {
 	get_first_visible_child,
 	get_last_visible_child,
-	get_n_visible_children,
 	get_next_visible_sibling,
 	get_previous_visible_sibling,
 } from '../misc/actor.js';
@@ -17,6 +16,7 @@ import { SearchChange, SearchQuery } from './searchEntry.js';
 @registerClass()
 export class ClipboardScrollContainer extends St.BoxLayout {
 	private readonly _statusItem: StatusItem;
+	private readonly _connectedItems = new WeakSet<ClipboardItem>();
 	private _lastFocus: Clutter.Actor | null = null;
 	private _lastQuery: SearchQuery | null = null;
 
@@ -32,19 +32,22 @@ export class ClipboardScrollContainer extends St.BoxLayout {
 	}
 
 	private updateVisible() {
-		const n = get_n_visible_children(this);
-		if (n === 0) {
-			this.add_child(this._statusItem);
+		let visibleItems = 0;
+		let hasItems = false;
+		for (const child of this.get_children()) {
+			if (!(child instanceof ClipboardItem)) continue;
+			hasItems = true;
+			if (child.visible) visibleItems++;
+		}
+
+		if (visibleItems === 0) {
+			if (this._statusItem.get_parent() === null) this.add_child(this._statusItem);
 			this.x_align = Clutter.ActorAlign.CENTER;
 			this.x_expand = true;
 
-			if (this.get_n_children() === 1) {
-				this._statusItem.state = State.Empty;
-			} else {
-				this._statusItem.state = State.NoResults;
-			}
-		} else if (n >= 2 && this._statusItem.get_parent() !== null) {
-			this.remove_child(this._statusItem);
+			this._statusItem.state = hasItems ? State.NoResults : State.Empty;
+		} else {
+			if (this._statusItem.get_parent() !== null) this.remove_child(this._statusItem);
 			this.x_align = Clutter.ActorAlign.START;
 			this.x_expand = false;
 		}
@@ -136,16 +139,31 @@ export class ClipboardScrollContainer extends St.BoxLayout {
 		this.removePseudoclasses();
 		if (this._statusItem.get_parent() !== null) this.remove_child(this._statusItem);
 
+		this.appendItems(items, false);
+
+		this.updateVisible();
+	}
+
+	public appendItems(items: ClipboardItem[], update: boolean = true): void {
+		if (items.length === 0) return;
+
+		this.removePseudoclasses();
+		if (this._statusItem.get_parent() !== null) this.remove_child(this._statusItem);
+
 		for (const item of items) {
+			if (this._lastQuery) item.search(this._lastQuery);
 			if (item.get_parent() === this) this.remove_child(item);
 			this.add_child(item);
 			this.connectItemSignals(item);
 		}
 
-		this.updateVisible();
+		if (update) this.updateVisible();
 	}
 
 	private connectItemSignals(item: ClipboardItem): void {
+		if (this._connectedItems.has(item)) return;
+		this._connectedItems.add(item);
+
 		// Move item when datetime changes
 		item.entry.connect('notify::datetime', () => this.insertOrMoveItem(item));
 
@@ -256,6 +274,7 @@ export class ClipboardScrollContainer extends St.BoxLayout {
 	public search(query: SearchQuery): void {
 		// Copy search query, but with SearchChange.Different to always force re-search
 		this._lastQuery = query.withChange(SearchChange.Different);
+		if (query.change === SearchChange.Same) return;
 
 		this.removePseudoclasses();
 		let focusChild: ClipboardItem | null = null;
@@ -293,6 +312,16 @@ export class ClipboardScrollContainer extends St.BoxLayout {
 		const first = get_first_visible_child(this);
 		if (first instanceof St.Button) {
 			first.vfunc_clicked(1);
+		}
+	}
+
+	public preWarm(maxItems: number = 24): void {
+		let n = 0;
+		for (const child of this.get_children()) {
+			if (!(child instanceof ClipboardItem) || !child.visible) continue;
+
+			child.get_preferred_size();
+			if (++n >= maxItems) return;
 		}
 	}
 

--- a/src/lib/ui/clipboardScrollContainer.ts
+++ b/src/lib/ui/clipboardScrollContainer.ts
@@ -122,11 +122,6 @@ export class ClipboardScrollContainer extends St.BoxLayout {
 
 	public addItem(item: ClipboardItem): void {
 		this.insertOrMoveItem(item);
-
-		if (this._lastQuery) {
-			item.search(this._lastQuery);
-		}
-
 		this.connectItemSignals(item);
 	}
 
@@ -165,16 +160,21 @@ export class ClipboardScrollContainer extends St.BoxLayout {
 		this._connectedItems.add(item);
 
 		// Move item when datetime changes
-		item.entry.connect('notify::datetime', () => this.insertOrMoveItem(item));
+		item.entry.connect('notify::datetime', () => this.insertOrMoveItem(item, false));
 
 		// Delete item when deleted
 		item.entry.connect('delete', () => this.removeItem(item));
 
-		// Update search when entry changes
-		item.entry.connect('notify', () => this.updateSearch(item));
+		// Update search only when a searchable property changes.
+		item.entry.connect('notify::content', () => this.updateSearch(item));
+		item.entry.connect('notify::pinned', () => this.updateSearch(item));
+		item.entry.connect('notify::tag', () => this.updateSearch(item));
+		item.entry.connect('notify::type', () => this.updateSearch(item));
+		item.entry.connect('notify::metadata', () => this.updateSearch(item));
+		item.entry.connect('notify::title', () => this.updateSearch(item));
 	}
 
-	private insertOrMoveItem(item: ClipboardItem): void {
+	private insertOrMoveItem(item: ClipboardItem, search: boolean = true): void {
 		this.removePseudoclasses();
 
 		if (item.get_parent() === this) this.remove_child(item);
@@ -192,8 +192,11 @@ export class ClipboardScrollContainer extends St.BoxLayout {
 			this.add_child(item);
 		}
 
-		this.updateSearch(item);
-		this.updateVisible();
+		if (search && this._lastQuery) {
+			this.updateSearch(item);
+		} else {
+			this.updateVisible();
+		}
 	}
 
 	public clearItems(): void {
@@ -322,6 +325,17 @@ export class ClipboardScrollContainer extends St.BoxLayout {
 
 			child.get_preferred_size();
 			if (++n >= maxItems) return;
+		}
+	}
+
+	public loadPreviews(start: number, end: number): void {
+		for (const child of this.get_children()) {
+			if (!(child instanceof ClipboardItem) || !child.visible) continue;
+
+			const box = child.get_allocation_box();
+			const itemStart = this.orientation === Clutter.Orientation.HORIZONTAL ? box.x1 : box.y1;
+			const itemEnd = this.orientation === Clutter.Orientation.HORIZONTAL ? box.x2 : box.y2;
+			if (itemEnd >= start && itemStart <= end) child.loadPreview();
 		}
 	}
 

--- a/src/lib/ui/clipboardScrollView.ts
+++ b/src/lib/ui/clipboardScrollView.ts
@@ -82,6 +82,10 @@ export class ClipboardScrollView extends St.ScrollView {
 		this._scrollContainer.addItem(item);
 	}
 
+	public loadItems(items: ClipboardItem[]) {
+		this._scrollContainer.loadItems(items);
+	}
+
 	public clearItems() {
 		this._scrollContainer.clearItems();
 	}

--- a/src/lib/ui/clipboardScrollView.ts
+++ b/src/lib/ui/clipboardScrollView.ts
@@ -86,6 +86,10 @@ export class ClipboardScrollView extends St.ScrollView {
 		this._scrollContainer.loadItems(items);
 	}
 
+	public appendItems(items: ClipboardItem[]) {
+		this._scrollContainer.appendItems(items);
+	}
+
 	public clearItems() {
 		this._scrollContainer.clearItems();
 	}
@@ -104,6 +108,11 @@ export class ClipboardScrollView extends St.ScrollView {
 
 	public activateFirst() {
 		this._scrollContainer.activateFirst();
+	}
+
+	public preWarm() {
+		this.get_preferred_size();
+		this._scrollContainer.preWarm();
 	}
 
 	private updateSize() {

--- a/src/lib/ui/clipboardScrollView.ts
+++ b/src/lib/ui/clipboardScrollView.ts
@@ -1,4 +1,5 @@
 import Clutter from 'gi://Clutter';
+import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 import St from 'gi://St';
 
@@ -23,6 +24,7 @@ export class ClipboardScrollView extends St.ScrollView {
 	private _orientation: Clutter.Orientation = Clutter.Orientation.HORIZONTAL;
 	private _itemWidth: number = 0;
 	private _itemHeight: number = 0;
+	private _previewLoadIdleId: number = 0;
 
 	private readonly _scrollContainer: ClipboardScrollContainer;
 
@@ -48,6 +50,24 @@ export class ClipboardScrollView extends St.ScrollView {
 
 		this.connect('notify::width', this.scrollbarWorkaround.bind(this));
 		this._scrollContainer.connect('notify::width', this.scrollbarWorkaround.bind(this));
+		this.hadjustment.connectObject(
+			'notify::value',
+			this.schedulePreviewLoad.bind(this),
+			'notify::upper',
+			this.schedulePreviewLoad.bind(this),
+			'notify::page-size',
+			this.schedulePreviewLoad.bind(this),
+			this,
+		);
+		this.vadjustment.connectObject(
+			'notify::value',
+			this.schedulePreviewLoad.bind(this),
+			'notify::upper',
+			this.schedulePreviewLoad.bind(this),
+			'notify::page-size',
+			this.schedulePreviewLoad.bind(this),
+			this,
+		);
 
 		// Connect properties
 		this.ext.settings.connectObject(
@@ -76,18 +96,22 @@ export class ClipboardScrollView extends St.ScrollView {
 		this._orientation = value;
 		this.notify('orientation');
 		this.updateScrollbar();
+		this.schedulePreviewLoad();
 	}
 
 	public addItem(item: ClipboardItem) {
 		this._scrollContainer.addItem(item);
+		this.schedulePreviewLoad();
 	}
 
 	public loadItems(items: ClipboardItem[]) {
 		this._scrollContainer.loadItems(items);
+		this.schedulePreviewLoad();
 	}
 
 	public appendItems(items: ClipboardItem[]) {
 		this._scrollContainer.appendItems(items);
+		this.schedulePreviewLoad();
 	}
 
 	public clearItems() {
@@ -104,6 +128,7 @@ export class ClipboardScrollView extends St.ScrollView {
 
 	public search(query: SearchQuery) {
 		this._scrollContainer.search(query);
+		this.schedulePreviewLoad();
 	}
 
 	public activateFirst() {
@@ -113,6 +138,24 @@ export class ClipboardScrollView extends St.ScrollView {
 	public preWarm() {
 		this.get_preferred_size();
 		this._scrollContainer.preWarm();
+	}
+
+	private schedulePreviewLoad(): void {
+		if (this._previewLoadIdleId) return;
+
+		this._previewLoadIdleId = GLib.idle_add(GLib.PRIORITY_LOW, () => {
+			this._previewLoadIdleId = 0;
+			if (!this.get_parent()) return GLib.SOURCE_REMOVE;
+
+			const adjustment =
+				this._orientation === Clutter.Orientation.HORIZONTAL ? this.hadjustment : this.vadjustment;
+			if (adjustment.page_size <= 0) return GLib.SOURCE_REMOVE;
+
+			const start = Math.max(adjustment.lower, adjustment.value - adjustment.page_size);
+			const end = Math.min(adjustment.upper, adjustment.value + adjustment.page_size * 2);
+			this._scrollContainer.loadPreviews(start, end);
+			return GLib.SOURCE_REMOVE;
+		});
 	}
 
 	private updateSize() {
@@ -226,8 +269,17 @@ export class ClipboardScrollView extends St.ScrollView {
 	}
 
 	override destroy() {
+		if (this._previewLoadIdleId) GLib.source_remove(this._previewLoadIdleId);
+		this._previewLoadIdleId = 0;
+		this.hadjustment.disconnectObject(this);
+		this.vadjustment.disconnectObject(this);
 		this.ext.settings.disconnectObject(this);
 
 		super.destroy();
+	}
+
+	override vfunc_map(): void {
+		super.vfunc_map();
+		this.schedulePreviewLoad();
 	}
 }

--- a/src/lib/ui/components/contentInfo.ts
+++ b/src/lib/ui/components/contentInfo.ts
@@ -12,7 +12,10 @@ import type CopyousExtension from '../../../extension.js';
 import { enumParamSpec, registerClass } from '../../common/gjs.js';
 import { Icon, loadIcon } from '../../common/icons.js';
 import { TextCountMode } from '../../common/settings.js';
-import { FileType } from './contentPreview.js';
+import { FileType, ImageDimensions } from './contentPreview.js';
+
+const GraphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+const WordSegmenter = new Intl.Segmenter(undefined, { granularity: 'word' });
 
 function formatBytes(bytes: number): [string, string] {
 	const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
@@ -34,6 +37,14 @@ function formatTime(seconds: number): string {
 	res += _('%ds').format(s);
 
 	return res;
+}
+
+function countLines(text: string): number {
+	let count = 1;
+	for (let i = 0; i < text.length; i++) {
+		if (text[i] === '\n') count++;
+	}
+	return count;
 }
 
 @registerClass()
@@ -100,20 +111,18 @@ export class TextInfo extends ContentInfo {
 	private updateCount() {
 		if (this._textCountMode === TextCountMode.Characters) {
 			let count = 0;
-			const segments = new Intl.Segmenter(undefined, { granularity: 'grapheme' }).segment(this._text);
-			for (const _segment of segments) count++;
+			for (const _segment of GraphemeSegmenter.segment(this._text)) count++;
 
 			this._countLabel.text = ngettext('%d char', '%d chars', count).format(count);
 		} else if (this._textCountMode === TextCountMode.Words) {
 			let count = 0;
-			const segments = new Intl.Segmenter(undefined, { granularity: 'word' }).segment(this._text);
-			for (const segment of segments) {
+			for (const segment of WordSegmenter.segment(this._text)) {
 				if (segment.isWordLike) count++;
 			}
 
 			this._countLabel.text = ngettext('%d word', '%d words', count).format(count);
 		} else if (this._textCountMode === TextCountMode.Lines) {
-			const count = this._text.split('\n').length;
+			const count = countLines(this._text);
 			this._countLabel.text = ngettext('%d line', '%d lines', count).format(count);
 		}
 	}
@@ -329,6 +338,7 @@ export async function createFileInfo(
 	file: Gio.File,
 	fileType: FileType,
 	cancellable: Gio.Cancellable,
+	imageDimensions?: ImageDimensions | null,
 ): Promise<FileInfo> {
 	try {
 		if (!file.query_exists(null)) {
@@ -349,7 +359,9 @@ export async function createFileInfo(
 				fileInfo = await tryCreateDirectoryFileInfo(ext, file);
 				break;
 			case FileType.Image:
-				fileInfo = tryCreateImageInfo(file, size);
+				fileInfo = imageDimensions
+					? new ImageInfo(size, imageDimensions.width, imageDimensions.height)
+					: tryCreateImageInfo(file, size);
 				break;
 			case FileType.Audio:
 			case FileType.Video:

--- a/src/lib/ui/components/contentPreview.ts
+++ b/src/lib/ui/components/contentPreview.ts
@@ -25,6 +25,11 @@ export const FileType = {
 
 export type FileType = (typeof FileType)[keyof typeof FileType];
 
+export interface ImageDimensions {
+	width: number;
+	height: number;
+}
+
 @registerClass()
 export class ContentPreview extends St.BoxLayout {
 	constructor() {
@@ -34,6 +39,65 @@ export class ContentPreview extends St.BoxLayout {
 			x_expand: true,
 			y_expand: true,
 		});
+	}
+}
+
+const IMAGE_PREVIEW_SIZE = 512;
+
+@registerClass()
+class AsyncImageBox extends St.Widget {
+	private _backgroundSize: BackgroundSize = BackgroundSize.Cover;
+	private readonly _texture: Clutter.Actor;
+
+	constructor(
+		image: Gio.File,
+		private readonly _ratio: number,
+	) {
+		super({
+			style_class: 'image-box',
+			x_align: Clutter.ActorAlign.FILL,
+			y_align: Clutter.ActorAlign.FILL,
+			x_expand: true,
+			y_expand: true,
+			clip_to_allocation: true,
+		});
+
+		const paintScale = St.ThemeContext.get_for_stage(global.stage).scale_factor;
+		this._texture = St.TextureCache.get_default().load_file_async(
+			image,
+			IMAGE_PREVIEW_SIZE,
+			IMAGE_PREVIEW_SIZE,
+			paintScale,
+			this.get_resource_scale(),
+		);
+		this.add_child(this._texture);
+	}
+
+	set backgroundSize(backgroundSize: BackgroundSize) {
+		if (this._backgroundSize === backgroundSize) return;
+		this._backgroundSize = backgroundSize;
+		this.queue_relayout();
+	}
+
+	override vfunc_allocate(box: Clutter.ActorBox): void {
+		this.set_allocation(box);
+
+		const width = box.get_width();
+		const height = box.get_height();
+		if (width <= 0 || height <= 0) return;
+
+		const widthScale = width;
+		const heightScale = height / this._ratio;
+		const scale =
+			this._backgroundSize === BackgroundSize.Cover
+				? Math.max(widthScale, heightScale)
+				: Math.min(widthScale, heightScale);
+		const imageWidth = scale;
+		const imageHeight = scale * this._ratio;
+		const x = Math.floor((width - imageWidth) / 2);
+		const y = Math.floor((height - imageHeight) / 2);
+
+		this._texture.allocate(Clutter.ActorBox.new(x, y, x + imageWidth, y + imageHeight));
 	}
 }
 
@@ -51,30 +115,25 @@ export class ContentPreview extends St.BoxLayout {
 export class ImagePreview extends ContentPreview {
 	private _backgroundSize: BackgroundSize = BackgroundSize.Cover;
 	private readonly _ratio: number | null;
-	private readonly _effect?: Clutter.BrightnessContrastEffect;
+	private readonly _image: Gio.File;
+	private _imageBox?: AsyncImageBox;
+	private _effect?: Clutter.BrightnessContrastEffect;
 
-	constructor(ext: Extension, image: Gio.File) {
+	constructor(ext: Extension, image: Gio.File, dimensions?: ImageDimensions | null, load: boolean = true) {
 		super();
 
+		this._image = image;
 		this.add_style_class_name('image-preview');
 
 		if (image.query_exists(null)) {
 			try {
-				const [, width, height] = GdkPixbuf.Pixbuf.get_file_info(image.get_path()!);
+				let width = dimensions?.width ?? 0;
+				let height = dimensions?.height ?? 0;
+				if (width <= 0 || height <= 0) {
+					[, width, height] = GdkPixbuf.Pixbuf.get_file_info(image.get_path()!);
+				}
 				this._ratio = height / width;
-
-				const imageBox = new St.Widget({
-					style_class: 'image-box',
-					x_align: Clutter.ActorAlign.FILL,
-					y_align: Clutter.ActorAlign.FILL,
-					x_expand: true,
-					y_expand: true,
-					style: `background-image: url("${image.get_uri()}");`,
-				});
-				this.add_child(imageBox);
-
-				this._effect = new Clutter.BrightnessContrastEffect();
-				imageBox.add_effect(this._effect);
+				if (load) this.load();
 				return;
 			} catch {
 				// Ignore
@@ -95,6 +154,17 @@ export class ImagePreview extends ContentPreview {
 		);
 	}
 
+	public load(): void {
+		if (this._ratio === null || this._imageBox) return;
+
+		this._imageBox = new AsyncImageBox(this._image, this._ratio);
+		this._imageBox.backgroundSize = this._backgroundSize;
+		this.add_child(this._imageBox);
+
+		this._effect = new Clutter.BrightnessContrastEffect();
+		this._imageBox.add_effect(this._effect);
+	}
+
 	get backgroundSize() {
 		return this._backgroundSize;
 	}
@@ -108,6 +178,7 @@ export class ImagePreview extends ContentPreview {
 		} else {
 			this.add_style_class_name('contain');
 		}
+		if (this._imageBox) this._imageBox.backgroundSize = backgroundSize;
 	}
 
 	set active(active: ActiveState) {

--- a/src/lib/ui/components/editDialog.ts
+++ b/src/lib/ui/components/editDialog.ts
@@ -94,13 +94,17 @@ export class MultilineEntry extends St.Entry {
 			style_class: 'multiline-scrollview',
 			hscrollbar_policy: St.PolicyType.NEVER,
 			vscrollbar_policy: St.PolicyType.AUTOMATIC,
+			x_align: Clutter.ActorAlign.FILL,
+			y_align: Clutter.ActorAlign.FILL,
 			x_expand: true,
+			y_expand: true,
 			clip_to_allocation: true,
 		});
 		this.add_child(scrollView);
 
 		const box = new St.BoxLayout({
 			style_class: 'multiline-box',
+			orientation: Clutter.Orientation.VERTICAL,
 			x_align: Clutter.ActorAlign.FILL,
 			y_align: Clutter.ActorAlign.FILL,
 			x_expand: true,
@@ -114,6 +118,10 @@ export class MultilineEntry extends St.Entry {
 		text.activatable = false;
 		text.line_wrap = true;
 		text.line_wrap_mode = Pango.WrapMode.WORD_CHAR;
+		text.x_align = Clutter.ActorAlign.FILL;
+		text.y_align = Clutter.ActorAlign.START;
+		text.x_expand = true;
+		text.y_expand = true;
 
 		// Always keep the cursor visible
 		text.connect('cursor-changed', () => {
@@ -290,12 +298,13 @@ export class EditDialog extends ModalDialog.ModalDialog {
 		this._entry = new MultilineEntry({
 			style_class: 'clipboard-item-edit-dialog-entry',
 			can_focus: true,
+			x_expand: true,
 		});
 		content.add_child(this._entry);
 		this.setInitialKeyFocus(this._entry);
 
-		this._entry.clutterText.text = entry.content;
-		this._entry.clutterText.set_selection(0, 0);
+		this._entry.clutter_text.text = entry.content;
+		this._entry.clutter_text.set_selection(-1, -1);
 
 		if (entry.type === ItemType.Code) {
 			this._entry.add_style_class_name('monospace');
@@ -312,7 +321,7 @@ export class EditDialog extends ModalDialog.ModalDialog {
 		this.addButton({
 			label: _('Save'),
 			action: () => {
-				entry.content = this._entry.clutterText.text;
+				entry.content = this._entry.clutter_text.text;
 				if (this._languageButton) entry.metadata = { language: this._languageButton.language };
 				this.close();
 			},
@@ -320,6 +329,9 @@ export class EditDialog extends ModalDialog.ModalDialog {
 	}
 
 	on_opened() {
-		this._entry.clutterText.queue_relayout();
+		this._entry.clutter_text.grab_key_focus();
+		this._entry.clutter_text.set_selection(-1, -1);
+		this._entry.clutter_text.queue_relayout();
+		this._entry.clutter_text.queue_redraw();
 	}
 }

--- a/src/lib/ui/indicator.ts
+++ b/src/lib/ui/indicator.ts
@@ -40,7 +40,7 @@ export class ConfirmClearHistoryDialog extends ModalDialog.ModalDialog {
 		});
 		this.contentLayout.add_child(content);
 
-		const checkbox = new CheckBox.CheckBox(_('Clear Pinned/Tagged Items'));
+		const checkbox = new CheckBox.CheckBox(_('Clear Pinned Items'));
 		content.add_child(checkbox);
 
 		this.addButton({
@@ -53,10 +53,7 @@ export class ConfirmClearHistoryDialog extends ModalDialog.ModalDialog {
 		this.addButton({
 			label: _('Clear'),
 			action: () => {
-				this.emit(
-					'clear-history',
-					checkbox.checked ? ClipboardHistory.Clear : ClipboardHistory.KeepPinnedAndTagged,
-				);
+				this.emit('clear-history', checkbox.checked ? ClipboardHistory.Clear : ClipboardHistory.KeepPinned);
 				this.close();
 			},
 		});

--- a/src/lib/ui/items/clipboardItem.ts
+++ b/src/lib/ui/items/clipboardItem.ts
@@ -33,6 +33,7 @@ export class ClipboardItem extends St.Button {
 	private _protectPinned: boolean = true;
 	private _protectTagged: boolean = true;
 	private _middleClickAction: MiddleClickAction = MiddleClickAction.None;
+	private _headerShown: boolean | null = null;
 
 	private readonly _box: St.Widget;
 	private readonly _header: ClipboardItemHeader;
@@ -176,14 +177,24 @@ export class ClipboardItem extends St.Button {
 		this._header.showTitle = this.ext.settings.get_boolean('show-item-title');
 		this._header.controlsVisibility = this.ext.settings.get_enum('header-controls-visibility');
 
+		// Skip the layout-manager / sibling swap when state is unchanged: this
+		// is called once per item during bulk load, and replacing layout_manager
+		// triggers a full relayout pass per item.
+		if (this._headerShown === show) return;
+		this._headerShown = show;
+
 		if (show) {
 			this.remove_style_class_name('no-header');
 			this._box.set_child_above_sibling(this._content, this._header);
-			this._box.layout_manager = new Clutter.BoxLayout({ orientation: Clutter.Orientation.VERTICAL });
+			if (!(this._box.layout_manager instanceof Clutter.BoxLayout)) {
+				this._box.layout_manager = new Clutter.BoxLayout({ orientation: Clutter.Orientation.VERTICAL });
+			}
 		} else {
 			this.add_style_class_name('no-header');
 			this._box.set_child_above_sibling(this._header, this._content);
-			this._box.layout_manager = new Clutter.BinLayout();
+			if (!(this._box.layout_manager instanceof Clutter.BinLayout)) {
+				this._box.layout_manager = new Clutter.BinLayout();
+			}
 		}
 	}
 

--- a/src/lib/ui/items/clipboardItem.ts
+++ b/src/lib/ui/items/clipboardItem.ts
@@ -34,6 +34,7 @@ export class ClipboardItem extends St.Button {
 	private _protectTagged: boolean = true;
 	private _middleClickAction: MiddleClickAction = MiddleClickAction.None;
 	private _headerShown: boolean | null = null;
+	private _searchText: readonly string[] | null = null;
 
 	private readonly _box: St.Widget;
 	private readonly _header: ClipboardItemHeader;
@@ -121,6 +122,15 @@ export class ClipboardItem extends St.Button {
 		this.updateHeader();
 
 		// Connect signals
+		entry.connectObject(
+			'notify::content',
+			this.invalidateSearchText.bind(this),
+			'notify::metadata',
+			this.invalidateSearchText.bind(this),
+			'notify::title',
+			this.invalidateSearchText.bind(this),
+			this,
+		);
 		this.connect('notify::hover', () => this.notify('active'));
 		this.connect('style-changed', () => this.notify('active'));
 		this._header.connect('delete', () => this.forceDelete());
@@ -137,7 +147,20 @@ export class ClipboardItem extends St.Button {
 	}
 
 	public search(query: SearchQuery) {
-		this.visible = query.matchesEntry(this.visible, this.entry, this.entry.content);
+		this.visible = query.matchesEntry(this.visible, this.entry, ...this.searchText);
+	}
+
+	protected createSearchText(): readonly string[] {
+		return [this.entry.content];
+	}
+
+	protected invalidateSearchText(): void {
+		this._searchText = null;
+	}
+
+	private get searchText(): readonly string[] {
+		this._searchText ??= this.createSearchText();
+		return this._searchText;
 	}
 
 	private updateSize() {
@@ -312,6 +335,7 @@ export class ClipboardItem extends St.Button {
 
 	override destroy() {
 		this.ext.settings.disconnectObject(this);
+		this.entry.disconnectObject(this);
 
 		super.destroy();
 	}

--- a/src/lib/ui/items/clipboardItem.ts
+++ b/src/lib/ui/items/clipboardItem.ts
@@ -150,6 +150,8 @@ export class ClipboardItem extends St.Button {
 		this.visible = query.matchesEntry(this.visible, this.entry, ...this.searchText);
 	}
 
+	public loadPreview(): void {}
+
 	protected createSearchText(): readonly string[] {
 		return [this.entry.content];
 	}

--- a/src/lib/ui/items/fileItem.ts
+++ b/src/lib/ui/items/fileItem.ts
@@ -23,7 +23,6 @@ import {
 	getFileType,
 	tryCreateFilePreview,
 } from '../components/contentPreview.js';
-import { SearchQuery } from '../searchEntry.js';
 import { ClipboardItem } from './clipboardItem.js';
 
 export function formatFile(file: Gio.File): string {
@@ -45,6 +44,7 @@ export class FileItem extends ClipboardItem {
 	private _thumbnail?: Gio.File | null;
 	private _filePreview?: ContentPreview | null;
 	private _fileInfo?: ContentInfo;
+	private _previewIdleId: number = 0;
 
 	private readonly _cancellable: Gio.Cancellable = new Gio.Cancellable();
 
@@ -68,12 +68,16 @@ export class FileItem extends ClipboardItem {
 		// Bind properties
 		this.fileItemSettings.connectObject('changed', this.updateFilePreview.bind(this), this);
 		const logger = this.ext.logger;
-		this.updateFilePreview().catch(logger.error.bind(logger));
+		this._previewIdleId = GLib.idle_add(GLib.PRIORITY_LOW, () => {
+			this._previewIdleId = 0;
+			this.updateFilePreview().catch(logger.error.bind(logger));
+			return GLib.SOURCE_REMOVE;
+		});
 	}
 
-	public override search(query: SearchQuery): void {
+	protected override createSearchText(): readonly string[] {
 		const file = this.entry.content.substring('file://'.length);
-		this.visible = query.matchesEntry(this.visible, this.entry, file, this._file.text);
+		return [file, this._file.text];
 	}
 
 	private async updateFilePreview() {
@@ -208,6 +212,10 @@ export class FileItem extends ClipboardItem {
 
 	override destroy() {
 		this.fileItemSettings.disconnectObject(this);
+		if (this._previewIdleId) {
+			GLib.source_remove(this._previewIdleId);
+			this._previewIdleId = 0;
+		}
 		this._cancellable.cancel();
 
 		super.destroy();

--- a/src/lib/ui/items/filesItem.ts
+++ b/src/lib/ui/items/filesItem.ts
@@ -10,7 +10,6 @@ import { registerClass } from '../../common/gjs.js';
 import { Icon } from '../../common/icons.js';
 import { ClipboardEntry } from '../../database/database.js';
 import { ContentPreview } from '../components/contentPreview.js';
-import { SearchQuery } from '../searchEntry.js';
 import { ClipboardItem } from './clipboardItem.js';
 import { formatFile } from './fileItem.js';
 
@@ -163,7 +162,7 @@ export class FilesItem extends ClipboardItem {
 		}
 	}
 
-	public override search(query: SearchQuery): void {
-		this.visible = query.matchesEntry(this.visible, this.entry, ...this._files, ...(this._formattedFiles ?? []));
+	protected override createSearchText(): readonly string[] {
+		return [...this._files, ...(this._formattedFiles ?? [])];
 	}
 }

--- a/src/lib/ui/items/imageItem.ts
+++ b/src/lib/ui/items/imageItem.ts
@@ -10,7 +10,6 @@ import { ImageItemSettings } from '../../common/settings.js';
 import { ClipboardEntry } from '../../database/database.js';
 import { ContentInfo, createFileInfo } from '../components/contentInfo.js';
 import { FileType, ImagePreview } from '../components/contentPreview.js';
-import { SearchQuery } from '../searchEntry.js';
 import { ClipboardItem } from './clipboardItem.js';
 
 @registerClass({
@@ -73,8 +72,8 @@ export class ImageItem extends ClipboardItem {
 		this.configureImageInfo();
 	}
 
-	override search(query: SearchQuery): void {
-		this.visible = query.matchesEntry(this.visible, this.entry);
+	protected override createSearchText(): readonly string[] {
+		return [];
 	}
 
 	private updateSettings() {

--- a/src/lib/ui/items/imageItem.ts
+++ b/src/lib/ui/items/imageItem.ts
@@ -7,7 +7,7 @@ import type CopyousExtension from '../../../extension.js';
 import { registerClass } from '../../common/gjs.js';
 import { Icon } from '../../common/icons.js';
 import { ImageItemSettings } from '../../common/settings.js';
-import { ClipboardEntry } from '../../database/database.js';
+import { ClipboardEntry, ImageMetadata } from '../../database/database.js';
 import { ContentInfo, createFileInfo } from '../components/contentInfo.js';
 import { FileType, ImagePreview } from '../components/contentPreview.js';
 import { ClipboardItem } from './clipboardItem.js';
@@ -33,7 +33,7 @@ export class ImageItem extends ClipboardItem {
 
 	private readonly _cancellable: Gio.Cancellable = new Gio.Cancellable();
 
-	constructor(ext: CopyousExtension, entry: ClipboardEntry) {
+	constructor(ext: CopyousExtension, entry: ClipboardEntry, loadPreview: boolean = true) {
 		super(ext, entry, Icon.Image, _('Image'));
 
 		this.imageItemSettings = this.ext.settings.get_child('image-item');
@@ -42,7 +42,16 @@ export class ImageItem extends ClipboardItem {
 		this.add_style_class_name('no-image-info');
 
 		const file = Gio.File.new_for_uri(entry.content);
-		this._imagePreview = new ImagePreview(ext, file);
+		const metadata = entry.metadata as Partial<ImageMetadata> | null;
+		const dimensions =
+			metadata &&
+			typeof metadata.width === 'number' &&
+			metadata.width > 0 &&
+			typeof metadata.height === 'number' &&
+			metadata.height > 0
+				? { width: metadata.width, height: metadata.height }
+				: null;
+		this._imagePreview = new ImagePreview(ext, file, dimensions, loadPreview);
 		this._content.add_child(this._imagePreview);
 
 		// Bind properties
@@ -76,6 +85,11 @@ export class ImageItem extends ClipboardItem {
 		return [];
 	}
 
+	public override loadPreview(): void {
+		this._imagePreview.load();
+		this._imagePreview.active = this.active;
+	}
+
 	private updateSettings() {
 		this.showImageInfo = this.imageItemSettings.get_boolean('show-image-info');
 		this._imagePreview.backgroundSize = this.imageItemSettings.get_enum('background-size');
@@ -83,7 +97,22 @@ export class ImageItem extends ClipboardItem {
 
 	private configureImageInfo() {
 		if (this._imageInfo === undefined && this.showImageInfo) {
-			createFileInfo(this.ext, Gio.File.new_for_uri(this.entry.content), FileType.Image, this._cancellable)
+			const metadata = this.entry.metadata as Partial<ImageMetadata> | null;
+			const dimensions =
+				metadata &&
+				typeof metadata.width === 'number' &&
+				metadata.width > 0 &&
+				typeof metadata.height === 'number' &&
+				metadata.height > 0
+					? { width: metadata.width, height: metadata.height }
+					: null;
+			createFileInfo(
+				this.ext,
+				Gio.File.new_for_uri(this.entry.content),
+				FileType.Image,
+				this._cancellable,
+				dimensions,
+			)
 				.then((imageInfo) => {
 					this._imageInfo = imageInfo;
 					this._content.add_child(this._imageInfo);

--- a/src/lib/ui/items/linkItem.ts
+++ b/src/lib/ui/items/linkItem.ts
@@ -1,4 +1,5 @@
 import Clutter from 'gi://Clutter';
+import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 import Gio from 'gi://Gio';
 import Pango from 'gi://Pango';
@@ -14,7 +15,6 @@ import { BackgroundSize, LinkItemSettings } from '../../common/settings.js';
 import { ClipboardEntry, LinkMetadata } from '../../database/database.js';
 import { tryGetLinkImage, tryGetMetadata } from '../../misc/link.js';
 import { ImagePreview } from '../components/contentPreview.js';
-import { SearchQuery } from '../searchEntry.js';
 import { ClipboardItem } from './clipboardItem.js';
 
 const SPACING = 3;
@@ -298,6 +298,7 @@ export class LinkItem extends ClipboardItem {
 	private readonly _url: St.Label;
 
 	private readonly _cancellable: Gio.Cancellable = new Gio.Cancellable();
+	private _previewIdleId: number = 0;
 
 	constructor(ext: CopyousExtension, entry: ClipboardEntry) {
 		super(ext, entry, Icon.Link, _('Link'));
@@ -315,20 +316,31 @@ export class LinkItem extends ClipboardItem {
 		this._content.add_child(this._url);
 
 		// Bind properties
-		this.linkItemSettings.connectObject('changed', this.updateLinkPreview.bind(this), this);
-		this.ext.settings.connectObject('changed::show-header', this.updateLinkPreview.bind(this), this);
+		this.linkItemSettings.connectObject('changed', this.queueLinkPreviewUpdate.bind(this), this);
+		this.ext.settings.connectObject('changed::show-header', this.queueLinkPreviewUpdate.bind(this), this);
 
 		this.bind_property('active', this._linkPreview, 'active', GObject.BindingFlags.DEFAULT);
 
-		this.updateLinkPreview().catch(() => {});
+		this.queueLinkPreviewUpdate();
 	}
 
-	public override search(query: SearchQuery): void {
+	protected override createSearchText(): readonly string[] {
 		const metadata: LinkMetadata = { title: null, description: null, image: null, ...this.entry.metadata };
 		const searchTexts = [this.entry.content];
 		if (metadata.title) searchTexts.push(metadata.title);
 		if (metadata.description) searchTexts.push(metadata.description);
-		this.visible = query.matchesEntry(this.visible, this.entry, ...searchTexts);
+		return searchTexts;
+	}
+
+	private queueLinkPreviewUpdate() {
+		if (this._previewIdleId) return;
+
+		const logger = this.ext.logger;
+		this._previewIdleId = GLib.idle_add(GLib.PRIORITY_LOW, () => {
+			this._previewIdleId = 0;
+			this.updateLinkPreview().catch(logger.error.bind(logger));
+			return GLib.SOURCE_REMOVE;
+		});
 	}
 
 	private async updateLinkPreview() {
@@ -370,6 +382,10 @@ export class LinkItem extends ClipboardItem {
 
 	override destroy() {
 		this.linkItemSettings.disconnectObject(this);
+		if (this._previewIdleId) {
+			GLib.source_remove(this._previewIdleId);
+			this._previewIdleId = 0;
+		}
 		this._cancellable.cancel();
 
 		super.destroy();

--- a/src/lib/ui/searchEntry.ts
+++ b/src/lib/ui/searchEntry.ts
@@ -15,11 +15,15 @@ import { Icon, loadIcon } from '../common/icons.js';
 import { ClipboardEntry } from '../database/database.js';
 import { TagsItem } from './components/tagsItem.js';
 
+// Reused across calls: constructing Intl.Collator is non-trivial, and a single
+// search batch invokes localeContains once per item per text field.
+const _collator = new Intl.Collator(undefined, { sensitivity: 'base' });
+
 function localeContains(text: string, query: string): boolean {
-	const collator = new Intl.Collator(undefined, { sensitivity: 'base' });
-	for (let offset = 0; offset <= text.length - query.length; offset++) {
-		const comparison = collator.compare(text.substring(offset, offset + query.length), query);
-		if (comparison === 0) return true;
+	const queryLen = query.length;
+	const limit = text.length - queryLen;
+	for (let offset = 0; offset <= limit; offset++) {
+		if (_collator.compare(text.substring(offset, offset + queryLen), query) === 0) return true;
 	}
 	return false;
 }

--- a/src/lib/ui/searchEntry.ts
+++ b/src/lib/ui/searchEntry.ts
@@ -89,9 +89,9 @@ export class SearchQuery extends GObject.Object {
 		if (this.change === SearchChange.LessStrict && state) return true;
 		if (this.change === SearchChange.MoreStrict && !state) return false;
 
-		// Include entry title in search texts
-		const searchTexts = entry.title ? [...text, entry.title] : text;
-		return this.matchesProperties(entry.pinned, entry.tag, entry.type) && this.matchesQuery(...searchTexts);
+		if (!this.matchesProperties(entry.pinned, entry.tag, entry.type)) return false;
+		if (this.matchesQuery(...text)) return true;
+		return entry.title ? this.matchesQuery(entry.title) : false;
 	}
 
 	public withChange(change: SearchChange): SearchQuery {
@@ -421,6 +421,7 @@ export class SearchEntry extends St.Entry {
 	get searchQuery(): SearchQuery {
 		const excludePinned = this.ext.settings.get_boolean('exclude-pinned');
 		const excludeTagged = this.ext.settings.get_boolean('exclude-tagged');
+		const query = this.text;
 
 		let change: SearchChange;
 		if (!this._prevSearch) {
@@ -428,9 +429,9 @@ export class SearchEntry extends St.Entry {
 		} else {
 			// Query
 			let queryChange: SearchChange;
-			if (this.text === this._prevSearch.query) queryChange = SearchChange.Same;
-			else if (this.text.includes(this._prevSearch.query)) queryChange = SearchChange.MoreStrict;
-			else if (this._prevSearch.query.includes(this.text)) queryChange = SearchChange.LessStrict;
+			if (query === this._prevSearch.query) queryChange = SearchChange.Same;
+			else if (query.includes(this._prevSearch.query)) queryChange = SearchChange.MoreStrict;
+			else if (this._prevSearch.query.includes(query)) queryChange = SearchChange.LessStrict;
 			else queryChange = SearchChange.Different;
 
 			change = queryChange;
@@ -479,7 +480,7 @@ export class SearchEntry extends St.Entry {
 				change = change === SearchChange.Same || change === typeChange ? typeChange : SearchChange.Different;
 		}
 
-		return new SearchQuery(change, this.text, this.pinned, excludePinned, this.tag, excludeTagged, this.type);
+		return new SearchQuery(change, query, this.pinned, excludePinned, this.tag, excludeTagged, this.type);
 	}
 
 	private search() {


### PR DESCRIPTION
Defer all heavy work in `enable()` to
`GLib.idle_add(GLib.PRIORITY_LOW, ...)` after the shell emits `startup-complete`, and lazy-import heavy modules
(`ThemeManager`, `ClipboardDialog`, `ClipboardIndicator`, `GDA`, etc.) in parallel via dynamic `import()`.

This eliminates the vanilla dock flash during cold boot, since the extension no longer competes with Mutter for the main loop during shell startup.

Clipboard history loading
-------------------------

Bulk-load the initial clipboard history through a new `loadEntries()` / `loadItems()` path that appends items directly. The database already returns rows ordered by descending datetime, so the previous `addEntry()` loop was unnecessarily expensive:

- linear scan per insertion
- per-item `updateSearch()`
- per-item `updateVisible()`
- per-item pseudoclass updates

Resulting in O(N²) behavior during startup.

Also remove the premature `search()` call from the dialog constructor and execute it once after the bulk load completes.

Lazy dialog layout
-------------------------

Make dialog layout fully lazy:

- `updatePosition()` and `updateMargins()` are no longer called from the constructor
- a `_layoutDirty` flag tracks pending layout updates
- layout is applied on first `open()` (or immediately if already open)

After bulk loading, schedule a hidden `preWarm()` pass at idle time to force a first allocation while the dialog is still invisible, so the first user-triggered open does not pay the layout cost from scratch.

Additional optimizations
-------------------------

- Reduce the open animation duration from 150ms to 100ms for snappier feedback.

- Cache `Intl.Collator` at module scope in `searchEntry.ts` so `localeContains()` no longer allocates a new collator per call. Previously, one collator was created per item, per text field, on every search keystroke.

- In `ClipboardItem.updateHeader()`, skip the `layout_manager` swap and `set_child_above_sibling()` call when the header visibility state has not changed, and only replace the layout manager when its type differs.

  This avoids allocating a new `Clutter.BoxLayout` per item during the initial bulk load.