### PR TITLE
fix: make toggle pinned search shortcut configurable

### DIFF
--- a/resources/schemas/org.gnome.shell.extensions.copyous.gschema.xml
+++ b/resources/schemas/org.gnome.shell.extensions.copyous.gschema.xml
@@ -366,6 +366,10 @@
 			<default>['&lt;Control&gt;a']</default>
 			<summary>Shortcut to open the menu of a clipboard item</summary>
 		</key>
+		<key name="toggle-pinned-search-shortcut" type="as">
+			<default>['&lt;Alt&gt;']</default>
+			<summary>Shortcut to toggle the pinned items search filter</summary>
+		</key>
 
 		<key name="middle-click-action" enum="org.gnome.shell.extensions.copyous.MiddleClickAction">
 			<default>'pin'</default>

--- a/src/lib/common/settings.ts
+++ b/src/lib/common/settings.ts
@@ -114,6 +114,7 @@ export const Settings = {
 	EditItemShortcut: 'edit-item-shortcut',
 	EditTitleShortcut: 'edit-title-shortcut',
 	OpenMenuShortcut: 'open-menu-shortcut',
+	TogglePinnedSearchShortcut: 'toggle-pinned-search-shortcut',
 
 	MiddleClickAction: 'middle-click-action',
 	SwapCopyShortcut: 'swap-copy-shortcut',
@@ -196,6 +197,7 @@ export const SettingsTypes = {
 	[Settings.EditItemShortcut]: 'strv',
 	[Settings.EditTitleShortcut]: 'strv',
 	[Settings.OpenMenuShortcut]: 'strv',
+	[Settings.TogglePinnedSearchShortcut]: 'strv',
 
 	[Settings.MiddleClickAction]: 'enum',
 	[Settings.SwapCopyShortcut]: 'boolean',

--- a/src/lib/misc/shortcuts.ts
+++ b/src/lib/misc/shortcuts.ts
@@ -21,6 +21,7 @@ export const Shortcut = {
 	Edit: 'edit-item-shortcut',
 	EditTitle: 'edit-title-shortcut',
 	Menu: 'open-menu-shortcut',
+	TogglePinnedSearch: 'toggle-pinned-search-shortcut',
 } as const;
 
 export type Shortcut = (typeof Shortcut)[keyof typeof Shortcut];
@@ -82,6 +83,7 @@ export class ShortcutManager extends GObject.Object {
 		this.registerShortcut(Shortcut.Edit);
 		this.registerShortcut(Shortcut.EditTitle);
 		this.registerShortcut(Shortcut.Menu);
+		this.registerShortcut(Shortcut.TogglePinnedSearch);
 
 		this._actor = actor;
 		actor.connectObject(

--- a/src/lib/preferences/shortcuts/searchShortcuts.ts
+++ b/src/lib/preferences/shortcuts/searchShortcuts.ts
@@ -1,5 +1,6 @@
 import Adw from 'gi://Adw';
 import GObject from 'gi://GObject';
+import Gio from 'gi://Gio';
 import Gtk from 'gi://Gtk';
 
 import { gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
@@ -7,6 +8,7 @@ import { gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensio
 import Preferences from '../../../prefs.js';
 import { registerClass } from '../../common/gjs.js';
 import { CopyousSettings } from '../../common/settings.js';
+import { makeResettable } from '../utils.js';
 import { ShortcutRow } from './shortcutRow.js';
 
 const ShortcutLabel = ('ShortcutLabel' in Gtk && !('ShortcutLabel' in Adw) ? (Gtk as typeof Adw) : Adw).ShortcutLabel;
@@ -45,12 +47,22 @@ class ScrollShortcutRow extends Adw.ActionRow {
 
 @registerClass()
 export class SearchShortcuts extends Adw.PreferencesGroup {
-	constructor() {
+	constructor(prefs: Preferences) {
 		super({ title: _('Search') });
 
-		this.add(new ShortcutRow(_('Toggle Pinned Search'), '<Alt>'));
+		const togglePinnedSearch = new ShortcutRow(_('Toggle Pinned Search'), '', true);
+		this.add(togglePinnedSearch);
 		this.add(new ShortcutRow(_('Clear Item Tag/Type'), 'Back'));
 		this.add(new ShortcutRow(_('Activate First Item'), 'Return'));
+
+		const settings: CopyousSettings = prefs.getSettings();
+		settings.bind(
+			'toggle-pinned-search-shortcut',
+			togglePinnedSearch,
+			'shortcuts',
+			Gio.SettingsBindFlags.DEFAULT,
+		);
+		makeResettable(togglePinnedSearch, settings, 'toggle-pinned-search-shortcut');
 	}
 }
 

--- a/src/lib/ui/clipboardDialog.ts
+++ b/src/lib/ui/clipboardDialog.ts
@@ -20,6 +20,7 @@ import { Icon, loadIcon } from '../common/icons.js';
 import { OpenClipboardDialogBehavior } from '../common/settings.js';
 import { ClipboardEntry } from '../database/database.js';
 import { VERSION } from '../misc/compatibility.js';
+import { Shortcut } from '../misc/shortcuts.js';
 import { ClipboardScrollView } from './clipboardScrollView.js';
 import { ClipboardItemMenu } from './components/clipboardItemMenu.js';
 import { ConfirmClearHistoryDialog } from './indicator.js';
@@ -766,8 +767,11 @@ export class ClipboardDialog extends St.Widget {
 			return this._header.searchEntry.clutter_text.event(event, false);
 		}
 
-		// Toggle pinned search: alt
-		if (key === Clutter.KEY_Alt_L || key === Clutter.KEY_Alt_R || key === Clutter.KEY_ISO_Level3_Shift) {
+		// Toggle pinned search
+		if (
+			this.ext.shortcutsManager?.getShortcutForKeyBinding(key, event.get_state()) ===
+			Shortcut.TogglePinnedSearch
+		) {
 			this._header.searchEntry.pinned = !this._header.searchEntry.pinned;
 			return Clutter.EVENT_STOP;
 		}

--- a/src/lib/ui/searchEntry.ts
+++ b/src/lib/ui/searchEntry.ts
@@ -13,6 +13,7 @@ import { ItemType, ItemTypes, Tag, Tags } from '../common/constants.js';
 import { enumParamSpec, registerClass } from '../common/gjs.js';
 import { Icon, loadIcon } from '../common/icons.js';
 import { ClipboardEntry } from '../database/database.js';
+import { Shortcut } from '../misc/shortcuts.js';
 import { TagsItem } from './components/tagsItem.js';
 
 const SearchCollator = new Intl.Collator(undefined, { sensitivity: 'base' });
@@ -526,8 +527,11 @@ export class SearchEntry extends St.Entry {
 			return Clutter.EVENT_STOP;
 		}
 
-		// Toggle pin: alt
-		if (key === Clutter.KEY_Alt_L || key === Clutter.KEY_Alt_R || key === Clutter.KEY_ISO_Level3_Shift) {
+		// Toggle pinned search
+		if (
+			this.ext.shortcutsManager?.getShortcutForKeyBinding(key, event.get_state()) ===
+			Shortcut.TogglePinnedSearch
+		) {
 			this.pinned = !this.pinned;
 			return Clutter.EVENT_STOP;
 		}

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -119,7 +119,7 @@ export default class Preferences extends ExtensionPreferences {
 		shortcuts.add(new ItemActivationShortcuts(this));
 		shortcuts.add(new PopupMenuShortcuts());
 		shortcuts.add(new NavigationShortcuts());
-		shortcuts.add(new SearchShortcuts());
+		shortcuts.add(new SearchShortcuts(this));
 		shortcuts.add(new SearchNavigationShortcuts());
 		shortcuts.add(new SearchScrollShortcuts(this));
 


### PR DESCRIPTION
## Summary

- Adds a `toggle-pinned-search-shortcut` setting (default `<Alt>`) so users can change or disable the pinned-items search filter shortcut from preferences
- Replaces hardcoded Alt key detection with proper accelerator matching via `ShortcutManager`, so Alt pressed as part of another combo no longer toggles the pinned filter

## Problem

I changed the default open shortcut to **Ctrl+Alt+C**. Opening the dialog worked fine, but closing it was frustrating: pressing Alt as part of that combo also toggled the pinned-items search filter, because the pinned shortcut was hardcoded to fire on any Alt keypress regardless of other modifiers. There was no way to change or remove that shortcut in preferences — "Toggle Pinned Search" was shown as read-only.

This fix lets you rebind or disable the pinned filter shortcut (Backspace in the editor disables it), and Alt is only treated as the pinned shortcut when it matches the configured binding — not when it's one key in Ctrl+Alt+C.

## Test plan

- [ ] Open Copyous settings → Shortcuts → Search and confirm "Toggle Pinned Search" is editable; set it to `<Alt>` and verify it still toggles the pin filter in the search bar
- [ ] Press Backspace in the shortcut editor to disable the shortcut; confirm Alt no longer toggles the pinned filter
- [ ] Set the open dialog shortcut to `Ctrl-Alt-C`; open and close the dialog with that combo and confirm the pinned filter is not toggled
- [ ] Set a custom shortcut (e.g. `Ctrl-Shift-p`) and confirm it toggles the pinned filter as expected